### PR TITLE
🦌 fix: remove empty log lines under TUI list items when no logs exist

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1196,16 +1196,13 @@ export default function Dashboard({ cwd }: { cwd: string }) {
                   <Text dimColor>{formatTime(agent.elapsed)}</Text>
                 </Box>
                 {/* Log lines */}
-                {Array.from({ length: LOG_LINES_PER_ENTRY }).map((_, j) => {
-                  const line = recentLogs[j];
-                  return (
-                    <Box key={j} paddingLeft={3}>
-                      <Text dimColor wrap="truncate">
-                        {line ? truncate(line, logWidth) : " "}
-                      </Text>
-                    </Box>
-                  );
-                })}
+                {recentLogs.map((line, j) => (
+                  <Box key={j} paddingLeft={3}>
+                    <Text dimColor wrap="truncate">
+                      {truncate(line, logWidth)}
+                    </Text>
+                  </Box>
+                ))}
               </Box>
             );
           })


### PR DESCRIPTION
## Summary

- TUI list entries previously always rendered 2 log lines per agent, even when there were no logs, producing blank space under every item.
- Changed the log line rendering to only output lines that have actual content (`recentLogs.map(...)` instead of `Array.from({ length: LOG_LINES_PER_ENTRY }).map(...)`).
- Agents with no logs now take only 1 row (title only); agents with logs show up to 2 lines as before.