### PR TITLE
🦌 fix: prepend common bin dirs to PATH in sandbox tmux scripts

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -866,6 +866,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     if (process.stdin.setRawMode) process.stdin.setRawMode(false);
 
     const tmuxScript = [
+      `export PATH="$PATH:/usr/bin:/usr/local/bin:/bin"`,
       `if command -v tmux >/dev/null 2>&1; then`,
       `  if ! tmux has-session -t deer-shell 2>/dev/null; then`,
       `    tmux new-session -d -s deer-shell -c ${agent.meta.worktreePath}`,
@@ -943,6 +944,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     if (process.stdin.setRawMode) process.stdin.setRawMode(false);
 
     const tmuxScript = [
+      `export PATH="$PATH:/usr/bin:/usr/local/bin:/bin"`,
       `if command -v tmux >/dev/null 2>&1; then`,
       `  if ! tmux has-session -t deer 2>/dev/null; then`,
       `    tmux new-session -d -s deer`,


### PR DESCRIPTION
## Summary

- `docker sandbox exec ... sh -c` launches `sh` with a minimal PATH that often excludes `/usr/bin`, where `apt-get` installs `tmux`
- `command -v tmux` therefore fails and the fallback "tmux not available" message is shown, even though tmux was successfully installed during sandbox setup
- Fix: prepend `$PATH:/usr/bin:/usr/local/bin:/bin` at the start of both tmux scripts in `attachToAgent` and `shellIntoAgent`

## Test plan

- [ ] Start a new agent session (tmux is installed during sandbox setup)
- [ ] Press the attach key — confirm the tmux session attaches instead of showing "tmux not available"
- [ ] Press the shell key — confirm a tmux shell opens instead of falling back to direct `sh`