### PR TITLE
🦌 fix: store deer temp files in GIT_DIR instead of worktree

### DIFF
--- a/scripts/setup-sandbox.sh
+++ b/scripts/setup-sandbox.sh
@@ -68,9 +68,11 @@ GIT_DIR="$(cd "$REPO_ROOT" && git rev-parse --absolute-git-dir)"
 
 # Temporary branch name — renamed to something descriptive after the session
 TEMP_BRANCH="deer/session-$(date +%s)-$(head -c4 /dev/urandom | xxd -p)"
-COMMIT_MSG_FILE=".agent-commit-message"
-BRANCH_NAME_FILE=".agent-branch-name"
-PR_BODY_FILE=".agent-pr-body"
+
+# Temp dir for deer artifacts — inside GIT_DIR so git never tracks them,
+# but still accessible inside the sandbox (GIT_DIR is mounted).
+DEER_TMP_DIR="$GIT_DIR/deer/$TEMP_BRANCH"
+mkdir -p "$DEER_TMP_DIR"
 
 # ── Create worktree ──────────────────────────────────────────────────
 
@@ -207,5 +209,5 @@ ok "Sandbox ready"
 # ── Output metadata as JSON to stdout ─────────────────────────────────
 
 cat <<EOF
-{"sandboxName":"$SANDBOX_NAME","worktreePath":"$WORKTREE_DIR","tempBranch":"$TEMP_BRANCH","baseBranch":"$BASE_BRANCH","sandboxHome":"$SANDBOX_HOME","model":"$MODEL"}
+{"sandboxName":"$SANDBOX_NAME","worktreePath":"$WORKTREE_DIR","tempBranch":"$TEMP_BRANCH","baseBranch":"$BASE_BRANCH","sandboxHome":"$SANDBOX_HOME","model":"$MODEL","deerTmpDir":"$DEER_TMP_DIR"}
 EOF

--- a/scripts/teardown-sandbox.sh
+++ b/scripts/teardown-sandbox.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Post-session teardown: commit changes, push branch, create PR.
 # Outputs JSON result to stdout on success.
 #
-# Usage: teardown-sandbox.sh <repo_root> <worktree_path> <sandbox_name> <temp_branch> <base_branch> [model]
+# Usage: teardown-sandbox.sh <repo_root> <worktree_path> <sandbox_name> <temp_branch> <base_branch> [model] [deer_tmp_dir]
 # Env:   GH_TOKEN (optional, falls back to gh auth token)
 
 REPO_ROOT="$1"
@@ -13,6 +13,9 @@ SANDBOX_NAME="$3"
 TEMP_BRANCH="$4"
 BASE_BRANCH="$5"
 MODEL="${6:-sonnet}"
+# Temp dir for deer artifacts (outside the worktree, inside GIT_DIR).
+# Falls back to WORKTREE_DIR for backward compatibility.
+DEER_TMP_DIR="${7:-$WORKTREE_DIR}"
 
 COMMIT_MSG_FILE=".agent-commit-message"
 BRANCH_NAME_FILE=".agent-branch-name"
@@ -33,31 +36,34 @@ ok "Sandbox stopped"
 
 # ── Clean up agent artifacts ─────────────────────────────────────────
 
-rm -f "$WORKTREE_DIR/.agent-prompt" "$WORKTREE_DIR/.agent-metadata-prompt"
+rm -f "$DEER_TMP_DIR/.agent-prompt" "$DEER_TMP_DIR/.agent-metadata-prompt"
 
 # ── Read agent-written metadata files ────────────────────────────────
 
-if [ -f "$WORKTREE_DIR/$COMMIT_MSG_FILE" ]; then
-  COMMIT_MSG=$(cat "$WORKTREE_DIR/$COMMIT_MSG_FILE")
-  rm -f "$WORKTREE_DIR/$COMMIT_MSG_FILE"
+if [ -f "$DEER_TMP_DIR/$COMMIT_MSG_FILE" ]; then
+  COMMIT_MSG=$(cat "$DEER_TMP_DIR/$COMMIT_MSG_FILE")
+  rm -f "$DEER_TMP_DIR/$COMMIT_MSG_FILE"
 else
   COMMIT_MSG="chore: changes from sandboxed Claude session"
 fi
 
 AGENT_BRANCH_SLUG=""
-if [ -f "$WORKTREE_DIR/$BRANCH_NAME_FILE" ]; then
-  AGENT_BRANCH_SLUG=$(cat "$WORKTREE_DIR/$BRANCH_NAME_FILE" | tr -d '\n' \
+if [ -f "$DEER_TMP_DIR/$BRANCH_NAME_FILE" ]; then
+  AGENT_BRANCH_SLUG=$(cat "$DEER_TMP_DIR/$BRANCH_NAME_FILE" | tr -d '\n' \
     | tr '[:upper:]' '[:lower:]' \
     | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//' \
     | cut -c1-50)
-  rm -f "$WORKTREE_DIR/$BRANCH_NAME_FILE"
+  rm -f "$DEER_TMP_DIR/$BRANCH_NAME_FILE"
 fi
 
 PR_BODY=""
-if [ -f "$WORKTREE_DIR/$PR_BODY_FILE" ]; then
-  PR_BODY=$(cat "$WORKTREE_DIR/$PR_BODY_FILE")
-  rm -f "$WORKTREE_DIR/$PR_BODY_FILE"
+if [ -f "$DEER_TMP_DIR/$PR_BODY_FILE" ]; then
+  PR_BODY=$(cat "$DEER_TMP_DIR/$PR_BODY_FILE")
+  rm -f "$DEER_TMP_DIR/$PR_BODY_FILE"
 fi
+
+# Clean up the session temp dir
+rm -rf "$DEER_TMP_DIR"
 
 # ── Clean up stale git locks ────────────────────────────────────────
 # The sandbox may have been killed mid-git-operation, leaving lock files.
@@ -81,7 +87,6 @@ fi
 if [ "$HAS_UNCOMMITTED" = true ]; then
   info "Committing uncommitted changes..."
   git -C "$WORKTREE_DIR" add -A
-  git -C "$WORKTREE_DIR" reset -- "$COMMIT_MSG_FILE" "$BRANCH_NAME_FILE" "$PR_BODY_FILE" .agent-prompt .agent-metadata-prompt 2>/dev/null || true
   # After cleanup, agent artifacts may have been the only changes — check before committing
   if ! git -C "$WORKTREE_DIR" diff --cached --quiet; then
     git -C "$WORKTREE_DIR" commit -m "$COMMIT_MSG"

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -19,6 +19,8 @@ interface SandboxMeta {
   baseBranch: string;
   sandboxHome: string;
   model: string;
+  /** Temp dir for deer artifacts (inside GIT_DIR, not tracked by git) */
+  deerTmpDir: string;
 }
 
 interface TeardownResult {
@@ -313,8 +315,8 @@ async function applyNetworkPolicy(sandboxName: string, allowlist: string[]): Pro
  * The caller should read stdout for NDJSON events.
  */
 async function startClaude(meta: SandboxMeta, prompt: string): Promise<ReturnType<typeof Bun.spawn>> {
-  // Write prompt to file in worktree to avoid shell escaping
-  const promptPath = join(meta.worktreePath, ".agent-prompt");
+  // Write prompt to temp dir outside worktree to avoid polluting the git working tree
+  const promptPath = join(meta.deerTmpDir, ".agent-prompt");
   await Bun.write(promptPath, prompt);
 
   const proc = Bun.spawn([
@@ -322,7 +324,7 @@ async function startClaude(meta: SandboxMeta, prompt: string): Promise<ReturnTyp
     "env", "-u", "ANTHROPIC_API_KEY",
     `CLAUDE_CODE_OAUTH_TOKEN=${process.env.CLAUDE_CODE_OAUTH_TOKEN}`,
     "sh", "-c",
-    `cd ${meta.worktreePath} && cat .agent-prompt | claude -p --output-format stream-json --verbose --dangerously-skip-permissions --model ${MODEL}`,
+    `cd ${meta.worktreePath} && cat ${meta.deerTmpDir}/.agent-prompt | claude -p --output-format stream-json --verbose --dangerously-skip-permissions --model ${MODEL}`,
   ], {
     stdout: "pipe",
     stderr: "pipe",
@@ -336,7 +338,7 @@ async function startClaude(meta: SandboxMeta, prompt: string): Promise<ReturnTyp
  * Build the follow-up prompt that asks the agent to write metadata files.
  * Includes the repo's PR template if one exists.
  */
-async function buildMetadataPrompt(worktreePath: string): Promise<string> {
+async function buildMetadataPrompt(worktreePath: string, deerTmpDir: string): Promise<string> {
   let prTemplate = "";
 
   const templatePaths = [
@@ -359,17 +361,17 @@ async function buildMetadataPrompt(worktreePath: string): Promise<string> {
     : `A pull request description with a summary of the changes.`;
 
   return [
-    "Your task is complete. Now write these three files in the project root:",
+    "Your task is complete. Now write these three files:",
     "",
-    "1. `.agent-branch-name`",
+    `1. \`${deerTmpDir}/.agent-branch-name\``,
     "   A short kebab-case name for a git branch describing your changes.",
     "   No prefix. Examples: fix-login-validation, add-user-avatar-upload",
     "",
-    "2. `.agent-commit-message`",
+    `2. \`${deerTmpDir}/.agent-commit-message\``,
     "   A conventional git commit message. First line is the subject (<72 chars),",
     "   then a blank line, then an optional body.",
     "",
-    `3. \`.agent-pr-body\``,
+    `3. \`${deerTmpDir}/.agent-pr-body\``,
     `   ${prSection}`,
     "",
     "Write these three files now. Do nothing else.",
@@ -383,8 +385,8 @@ async function buildMetadataPrompt(worktreePath: string): Promise<string> {
  * Non-fatal — if this fails or times out, teardown has fallbacks.
  */
 async function startClaudeMetadata(meta: SandboxMeta, agent: AgentState): Promise<void> {
-  const prompt = await buildMetadataPrompt(meta.worktreePath);
-  const promptPath = join(meta.worktreePath, ".agent-metadata-prompt");
+  const prompt = await buildMetadataPrompt(meta.worktreePath, meta.deerTmpDir);
+  const promptPath = join(meta.deerTmpDir, ".agent-metadata-prompt");
   await Bun.write(promptPath, prompt);
 
   const proc = Bun.spawn([
@@ -392,7 +394,7 @@ async function startClaudeMetadata(meta: SandboxMeta, agent: AgentState): Promis
     "env", "-u", "ANTHROPIC_API_KEY",
     `CLAUDE_CODE_OAUTH_TOKEN=${process.env.CLAUDE_CODE_OAUTH_TOKEN}`,
     "sh", "-c",
-    `cd ${meta.worktreePath} && cat .agent-metadata-prompt | claude -p --continue --output-format stream-json --verbose --dangerously-skip-permissions --model ${MODEL}`,
+    `cd ${meta.worktreePath} && cat ${meta.deerTmpDir}/.agent-metadata-prompt | claude -p --continue --output-format stream-json --verbose --dangerously-skip-permissions --model ${MODEL}`,
   ], {
     stdout: "pipe",
     stderr: "pipe",
@@ -430,7 +432,7 @@ async function startClaudeMetadata(meta: SandboxMeta, agent: AgentState): Promis
 async function teardownAgent(meta: SandboxMeta, cwd: string): Promise<TeardownResult> {
   const proc = Bun.spawn([
     "bash", join(SCRIPTS_DIR, "teardown-sandbox.sh"),
-    cwd, meta.worktreePath, meta.sandboxName, meta.tempBranch, meta.baseBranch, meta.model,
+    cwd, meta.worktreePath, meta.sandboxName, meta.tempBranch, meta.baseBranch, meta.model, meta.deerTmpDir,
   ], {
     cwd,
     stdout: "pipe",


### PR DESCRIPTION
## Summary

- Deer's temporary files (`.agent-prompt`, `.agent-metadata-prompt`, `.agent-branch-name`, `.agent-commit-message`, `.agent-pr-body`) were being written into the worktree directory, which git tracks — causing every session to have untracked file noise and pending changes in worktrees
- Files are now stored in `$GIT_DIR/deer/$TEMP_BRANCH/`, a per-session subdirectory inside the git directory (never tracked by git, already mounted in the Docker sandbox at the same host path)
- The path (`deerTmpDir`) flows from `setup-sandbox.sh` → JSON metadata → `SandboxMeta` → `teardown-sandbox.sh`
- The metadata prompt now uses absolute paths so the agent writes to `deerTmpDir` instead of the project root
- `teardown-sandbox.sh` cleans up the entire `DEER_TMP_DIR` at the end; backward-compatible fallback to `WORKTREE_DIR` if arg is absent

## Test plan

- [ ] Start a deer session and verify no `.agent-*` files appear in the worktree during or after the session
- [ ] Verify the session completes successfully with a commit, branch rename, and PR created
- [ ] Verify `$GIT_DIR/deer/` is cleaned up after teardown