### PR TITLE
🦌 fix: avoid UI hang when killing a deer task with x

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -458,10 +458,13 @@ function cleanupAgent(agent: AgentState, repoRoot: string) {
   }
   if (agent.timer) clearInterval(agent.timer);
   if (agent.meta) {
-    // Best-effort cleanup
-    try { Bun.spawnSync(["docker", "sandbox", "rm", agent.meta.sandboxName]); } catch { /* ignore */ }
-    try { Bun.spawnSync(["git", "-C", repoRoot, "worktree", "remove", "--force", agent.meta.worktreePath]); } catch { /* ignore */ }
-    try { Bun.spawnSync(["git", "-C", repoRoot, "branch", "-D", agent.meta.tempBranch]); } catch { /* ignore */ }
+    // Best-effort cleanup — fire-and-forget to avoid blocking the UI
+    const { sandboxName, worktreePath, tempBranch } = agent.meta;
+    (async () => {
+      try { await Bun.spawn(["docker", "sandbox", "rm", sandboxName]).exited; } catch { /* ignore */ }
+      try { await Bun.spawn(["git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath]).exited; } catch { /* ignore */ }
+      try { await Bun.spawn(["git", "-C", repoRoot, "branch", "-D", tempBranch]).exited; } catch { /* ignore */ }
+    })();
   }
 }
 


### PR DESCRIPTION
## Summary

Pressing `x` to kill a deer task caused the UI to hang for several seconds.

## Root Cause

`cleanupAgent` used `Bun.spawnSync` for three cleanup operations:
- `docker sandbox rm <sandboxName>`
- `git worktree remove --force <worktreePath>`
- `git branch -D <tempBranch>`

`spawnSync` blocks the main thread until each command completes. Docker container removal in particular can be slow, causing the visible hang.

## Fix

Replaced the three `Bun.spawnSync` calls with a fire-and-forget async IIFE using `Bun.spawn(...).exited`. The UI returns immediately on kill, and cleanup proceeds in the background.