### PR TITLE
🦌 fix: resolve TypeScript type errors in dashboard.tsx

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -798,12 +798,12 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       setAgents((prev) => [...prev]);
 
       // Drain stderr to prevent backpressure (fire-and-forget)
-      new Response(proc.stderr).text().then((text) => {
+      new Response(proc.stderr as ReadableStream<Uint8Array>).text().then((text) => {
         if (text.trim()) appendLog(agent, `[stderr] ${text.trim()}`);
       });
 
       // Parse NDJSON stream from stdout
-      const reader = proc.stdout.getReader();
+      const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
       const decoder = new TextDecoder();
       let buffer = "";
       let lastRender = 0;
@@ -833,7 +833,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       if (buffer.trim()) parseNdjsonLine(buffer, agent);
 
       const exitCode = await proc.exited;
-      if (agent.status === "cancelled") return;
+      if ((agent.status as AgentStatus) === "cancelled") return;
       // User attached interactively — attach handler owns teardown
       if (agent.userAttached) return;
 


### PR DESCRIPTION
## Summary

Fixes four TypeScript type errors in `src/dashboard.tsx` that caused `tsc --noEmit` to fail.

### Changes

- **`proc.stderr` / `proc.stdout` casts (lines 801, 806)**: `startClaude` returns `ReturnType<typeof Bun.spawn>`, which types `stdout`/`stderr` as `number | ReadableStream<Uint8Array> | undefined`. At runtime they are always `ReadableStream` (the process is spawned with `stdout: "pipe"` and `stderr: "pipe"`), but the broad return type loses that narrowing. Added `as ReadableStream<Uint8Array>` casts so `new Response(...)` and `.getReader()` type-check correctly.

- **`agent.status` comparison (line 836)**: TypeScript 5.x narrowed `agent.status` to the literal `"running"` after the assignment at line 792, causing a TS2367 error when comparing to `"cancelled"`. Added `as AgentStatus` cast to widen the type back to the full union before the comparison.

## Test plan

- [ ] `./node_modules/.bin/tsc --noEmit` passes with no errors