### PR TITLE
🦌 feat: sync dashboard state across instances via history file polling

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -670,18 +670,54 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   agentsRef.current = agents;
   const configRef = useRef<DeerConfig | null>(null);
 
+  // ── Sync state from history file (cross-instance source of truth) ──
+
+  const syncWithHistory = useCallback(async () => {
+    const fileTasks = await loadHistory(cwd);
+    const currentAgents = agentsRef.current;
+    const agentByTaskId = new Map(currentAgents.map(a => [a.taskId, a]));
+    const fileTaskIds = new Set(fileTasks.map(t => t.taskId));
+
+    const newAgents: AgentState[] = fileTasks.map(task => {
+      const existing = agentByTaskId.get(task.taskId);
+      if (existing && !existing.historical) {
+        return existing; // keep live process handle and timer
+      }
+      const id = existing?.id ?? nextId.current++;
+      return historicalAgent(task, id);
+    });
+
+    // Keep owned agents not yet written to the file (edge case: spawned but not yet persisted)
+    for (const agent of currentAgents) {
+      if (!agent.historical && !fileTaskIds.has(agent.taskId)) {
+        newAgents.push(agent);
+      }
+    }
+
+    const changed =
+      newAgents.length !== currentAgents.length ||
+      newAgents.some((a, i) => {
+        const cur = currentAgents[i];
+        return !cur || a.taskId !== cur.taskId || a.status !== cur.status || a.lastActivity !== cur.lastActivity;
+      });
+
+    if (changed) setAgents(newAgents);
+  }, [cwd]);
+
   // ── Load history + preflight on mount ─────────────────────────────
 
   useEffect(() => {
     runPreflight().then(setPreflight);
     loadConfig(cwd).then((cfg) => { configRef.current = cfg; });
-    loadHistory(cwd).then((tasks) => {
-      if (tasks.length === 0) return;
-      const historical = tasks.map((t, i) => historicalAgent(t, i + 1));
-      nextId.current = historical.length + 1;
-      setAgents(historical);
-    });
-  }, [cwd]);
+    syncWithHistory();
+  }, [cwd, syncWithHistory]);
+
+  // ── Poll history file for changes from other deer instances ────────
+
+  useEffect(() => {
+    const interval = setInterval(syncWithHistory, 2_000);
+    return () => clearInterval(interval);
+  }, [syncWithHistory]);
 
   // ── Cleanup on unmount ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds a `syncWithHistory` callback in `Dashboard` that reads the history file and merges its contents with in-memory agent state
- Replaces the one-time `loadHistory` call on mount with `syncWithHistory`, and adds a 2-second polling interval so all running instances stay in sync
- Agents owned by the current instance (non-historical, with live process handles and timers) are never replaced by the sync — only the read-only historical views are rebuilt from file data

## How it works

The history file (`~/.local/share/deer/history/{hash}.jsonl`) was already written immediately when a task is spawned (`status: "running"`) and updated on every state transition. The missing piece was reading it continuously. The polling loop makes the file the live source of truth: tasks started in window A appear in window B within 2 seconds, and final statuses (completed, failed, cancelled) propagate the same way.

## Test plan

- [ ] Open two deer windows against the same repo
- [ ] Start a task in window 1 — verify it appears in window 2 within ~2 seconds
- [ ] Let the task complete in window 1 — verify window 2 updates to the final status
- [ ] Dismiss a task in window 1 — verify it disappears from window 2 on next poll
- [ ] Verify tasks started before opening window 2 are visible on load
- [ ] Verify `tsc --noEmit` passes with no type errors