### PR TITLE
🦌 feat: show only valid keyboard shortcuts for selected entry

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1385,12 +1385,14 @@ export default function Dashboard({ cwd }: { cwd: string }) {
         ) : (
           <>
             <Text dimColor>Tab focus</Text>
-            <Text dimColor>j/k nav</Text>
-            <Text dimColor>⏎ attach/open</Text>
-            <Text dimColor>c continue</Text>
-            <Text dimColor>s shell</Text>
-            <Text dimColor>x kill</Text>
-            <Text dimColor>⌫ delete</Text>
+            {visibleAgents.length > 0 && <Text dimColor>j/k nav</Text>}
+            {selected && (selected.status === "running" || selected.result?.prUrl || selected.transcriptPath) && (
+              <Text dimColor>⏎ {selected.status === "running" ? "attach" : selected.result?.prUrl ? "open PR" : "open"}</Text>
+            )}
+            {selected && !isActive(selected) && <Text dimColor>c continue</Text>}
+            {selected?.meta && <Text dimColor>s shell</Text>}
+            {selected && <Text dimColor>x kill</Text>}
+            {selected && !isActive(selected) && <Text dimColor>⌫ delete</Text>}
             <Text dimColor>l logs</Text>
             <Text dimColor>q quit</Text>
           </>


### PR DESCRIPTION
## Summary

- The footer keyboard shortcuts legend now shows only the shortcuts that are valid for the currently selected list entry, rather than always displaying all shortcuts.

## Changes

Each shortcut is now conditionally rendered based on the selected agent's state:

| Shortcut | Shown when |
|----------|------------|
| `j/k nav` | List has items |
| `⏎ attach` | Selected agent is running |
| `⏎ open PR` | Selected agent has a PR URL |
| `⏎ open` | Selected agent has a transcript |
| `c continue` | Selected agent is inactive |
| `s shell` | Selected agent has a container (`meta`) |
| `x kill` | Any agent is selected |
| `⌫ delete` | Selected agent is inactive |
| `Tab`, `l`, `q` | Always visible |

The `⏎` label also adapts to reflect the actual action (`attach`, `open PR`, or `open`) depending on agent state.