### PR TITLE
🦌 feat: add separator between prompt input and keyboard shortcuts legend

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1377,6 +1377,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       </Box>
 
       {/* Footer / keybindings */}
+      <Text>{"─".repeat(termWidth)}</Text>
       <Box paddingX={1} gap={2}>
         {confirmQuit ? (
           <Text color="yellow" bold>


### PR DESCRIPTION
## Summary

Adds a horizontal separator line between the prompt input field and the keyboard shortcuts legend in the dashboard UI, matching the existing divider style used above the input bar.