### PR TITLE
Add Shift+Enter for multiline prompt input

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@types/react": "^19.0.0",
         "bun-types": "latest",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -106,6 +107,8 @@
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput, useApp, useStdout } from "ink";
-import { TextInput, Spinner } from "@inkjs/ui";
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import { Spinner } from "@inkjs/ui";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { generateTaskId, transcriptsDir, loadHistory, upsertHistory, removeFromHistory } from "./task";
@@ -859,6 +859,98 @@ function historicalAgent(task: PersistedTask, id: number): AgentState {
   });
 }
 
+// ── Prompt Input ─────────────────────────────────────────────────────
+
+/** Text input that supports Shift+Enter to insert newlines and Enter to submit. */
+function PromptInput({
+  defaultValue = "",
+  placeholder = "",
+  isDisabled = false,
+  onSubmit,
+}: {
+  defaultValue?: string;
+  placeholder?: string;
+  isDisabled?: boolean;
+  onSubmit?: (value: string) => void;
+}) {
+  const [value, setValue] = useState(defaultValue);
+  const [cursorOffset, setCursorOffset] = useState(defaultValue.length);
+
+  useInput(
+    (input, key) => {
+      if (
+        key.upArrow ||
+        key.downArrow ||
+        (key.ctrl && input === "c") ||
+        key.tab ||
+        (key.shift && key.tab)
+      ) {
+        return;
+      }
+
+      if (key.return) {
+        if (key.shift) {
+          const newValue = value.slice(0, cursorOffset) + "\n" + value.slice(cursorOffset);
+          setValue(newValue);
+          setCursorOffset((prev) => prev + 1);
+        } else {
+          onSubmit?.(value);
+        }
+        return;
+      }
+
+      if (key.leftArrow) {
+        setCursorOffset((prev) => Math.max(0, prev - 1));
+      } else if (key.rightArrow) {
+        setCursorOffset((prev) => Math.min(value.length, prev + 1));
+      } else if (key.backspace || key.delete) {
+        if (cursorOffset > 0) {
+          const newValue = value.slice(0, cursorOffset - 1) + value.slice(cursorOffset);
+          setValue(newValue);
+          setCursorOffset((prev) => prev - 1);
+        }
+      } else if (input) {
+        const newValue = value.slice(0, cursorOffset) + input + value.slice(cursorOffset);
+        setValue(newValue);
+        setCursorOffset((prev) => prev + 1);
+      }
+    },
+    { isActive: !isDisabled },
+  );
+
+  const parts = useMemo(() => {
+    if (isDisabled) {
+      return [<Text key="val" dimColor>{placeholder}</Text>];
+    }
+    if (value.length === 0) {
+      if (!placeholder) {
+        return [<Text key="cursor" inverse> </Text>];
+      }
+      return [
+        <Text key="cursor" inverse>{placeholder[0]}</Text>,
+        <Text key="rest" dimColor>{placeholder.slice(1)}</Text>,
+      ];
+    }
+    const result: React.ReactNode[] = [];
+    let i = 0;
+    for (const char of value) {
+      const displayChar = char === "\n" ? "↵" : char;
+      if (i === cursorOffset) {
+        result.push(<Text key={i} inverse>{displayChar}</Text>);
+      } else {
+        result.push(displayChar);
+      }
+      i++;
+    }
+    if (cursorOffset === value.length) {
+      result.push(<Text key="end-cursor" inverse> </Text>);
+    }
+    return result;
+  }, [value, cursorOffset, placeholder, isDisabled]);
+
+  return <Text>{parts}</Text>;
+}
+
 // ── Main Component ───────────────────────────────────────────────────
 
 export default function Dashboard({ cwd }: { cwd: string }) {
@@ -1507,9 +1599,9 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       <Box paddingX={1} gap={1}>
         <Text dimColor>{">"}</Text>
         {inputFocused ? (
-          <TextInput
+          <PromptInput
             key={inputKey}
-            placeholder={!preflightOk ? "preflight checks failed" : continueBranch ? `prompt for ${continueBranch} (Esc to cancel)` : "type prompt and press enter to launch agent"}
+            placeholder={!preflightOk ? "preflight checks failed" : continueBranch ? `prompt for ${continueBranch} (Esc to cancel)` : "type prompt and press Enter to launch agent (Shift+Enter for newline)"}
             isDisabled={!preflightOk}
             defaultValue={inputDefault}
             onSubmit={(value) => {


### PR DESCRIPTION
## Summary
- Replaces `@inkjs/ui` TextInput with a custom `PromptInput` component
- Supports Shift+Enter to insert newlines in the prompt
- Enter still submits the prompt as before

## Test plan
- [ ] Verify Shift+Enter inserts a newline in the prompt field
- [ ] Verify Enter submits the prompt
- [ ] Verify cursor navigation (left/right arrows) works
- [ ] Verify backspace/delete work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)