### PR TITLE
Fix Shift+Enter newline insertion in prompt input

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -301,6 +301,30 @@ function PromptInput({
   const [value, setValue] = useState(defaultValue);
   const [cursorOffset, setCursorOffset] = useState(defaultValue.length);
 
+  // Refs to avoid stale closures in the raw stdin listener below.
+  const valueRef = useRef(value);
+  const cursorOffsetRef = useRef(cursorOffset);
+  useEffect(() => { valueRef.current = value; }, [value]);
+  useEffect(() => { cursorOffsetRef.current = cursorOffset; }, [cursorOffset]);
+
+  // Handle Shift+Enter via the Kitty keyboard protocol escape sequence (\x1b[13;2u).
+  // Standard terminals send the same \r byte for Enter and Shift+Enter, so Ink's
+  // useInput cannot distinguish them. Terminals supporting the Kitty protocol
+  // (kitty, WezTerm, foot, etc.) send a distinct sequence that we intercept here.
+  useEffect(() => {
+    if (isDisabled) return;
+    const handleData = (data: Buffer) => {
+      if (data.toString() === "\x1b[13;2u") {
+        const cur = cursorOffsetRef.current;
+        const val = valueRef.current;
+        setValue(val.slice(0, cur) + "\n" + val.slice(cur));
+        setCursorOffset(cur + 1);
+      }
+    };
+    process.stdin.on("data", handleData);
+    return () => { process.stdin.off("data", handleData); };
+  }, [isDisabled]);
+
   useInput(
     (input, key) => {
       if (


### PR DESCRIPTION
## Summary

Shift+Enter was indistinguishable from Enter in the prompt input because standard terminals send the same `\r` byte for both. Ink's `useInput` has no way to tell them apart.

This fix intercepts the Kitty keyboard protocol escape sequence (`\x1b[13;2u`) directly from stdin, which terminals like kitty, WezTerm, and foot emit for Shift+Enter. When detected, a newline is inserted at the current cursor position.

## Changes

- Added a raw `process.stdin` data listener in `PromptInput` to detect the Kitty protocol Shift+Enter sequence
- Used refs (`valueRef`, `cursorOffsetRef`) to avoid stale closures in the listener
- Listener is registered only when the input is not disabled and cleaned up on unmount/disable

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.