### PR TITLE
Highlight tmux status bar when Ctrl+b prefix is active

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -105,10 +105,10 @@ export async function launchSandbox(options: SandboxOptions): Promise<SandboxSes
     // Status bar with detach instructions
     ["status", "on"],
     ["status-position", "bottom"],
-    ["status-style", "bg=#1a1a2e,fg=#e0e0e0"],
+    ["status-style", "#{?client_prefix,bg=#4a4a6e fg=#ffffff,bg=#1a1a2e fg=#e0e0e0}"],
     ["status-left", ""],
     ["status-right", " 🦌 deer | Ctrl+b [ to scroll | Ctrl+b d to detach "],
-    ["status-right-style", "bg=#1a1a2e,fg=#888888"],
+    ["status-right-style", "#{?client_prefix,bg=#4a4a6e fg=#ffffff,bg=#1a1a2e fg=#888888}"],
     ["status-justify", "left"],
   ];
   for (const [key, value] of tmuxSettings) {


### PR DESCRIPTION
## Summary

The tmux status bar did not visually indicate when the `Ctrl+b` prefix key was pressed. This adds a highlight effect using tmux's `client_prefix` conditional so users get clear feedback when the prefix is active.

## Changes

- Updated `status-style` to use `#{?client_prefix,...}` conditional: lighter background and white text when prefix is active
- Updated `status-right-style` with the same conditional so the right-side hint text also highlights on prefix press

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.