### PR TITLE
Fix task deletion blocked after PR merge

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -504,7 +504,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       let changed = false;
       for (let i = 0; i < toCheck.length; i++) {
         const state = results[i];
-        if (state !== null && state !== toCheck[i].prState) {
+        if (state !== toCheck[i].prState) {
           toCheck[i].prState = state;
           changed = true;
         }


### PR DESCRIPTION
## Summary

After a PR was merged, tasks could not be deleted. The PR state check was guarding against `null` states, which prevented the `prState` from updating when `checkPrState` returned `null` post-merge. Removing the `null` guard allows the state to propagate correctly, unblocking task deletion.

Also removes a stale security analysis document and cleans up the tmux prefix-highlight conditional styles that were no longer needed.

## Changes

- `src/dashboard.tsx`: Remove `state !== null` guard in PR state polling loop so null states can update `prState` and trigger task deletion
- `src/dashboard.tsx`: Remove Shift+Enter Kitty protocol handler (now handled elsewhere)
- `src/sandbox/index.ts`: Simplify tmux `status-style` and `status-right-style` — remove prefix-conditional formatting
- `docs/security-analysis-bwrap-proxy.md`: Delete stale security analysis document

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.