### PR TITLE
🦌 Prefix all deer PR titles with deer emoji

### DIFF
--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -23,6 +23,11 @@ interface PRMetadata {
   body: string;
 }
 
+export function ensureDeerEmojiPrefix(title: string): string {
+  if (title.startsWith("🦌 ")) return title;
+  return `🦌 ${title}`;
+}
+
 /**
  * Ask Claude to generate PR metadata (branch name, title, body) from the diff.
  * Falls back to a simple prompt-based title if Claude fails.
@@ -85,12 +90,12 @@ ${truncatedDiff}`;
 
     return {
       branchName: parsed.branchName.replace(/[^a-z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, ""),
-      title: parsed.title.slice(0, 70),
+      title: ensureDeerEmojiPrefix(parsed.title.slice(0, 70)),
       body: parsed.body,
     };
   } catch {
     const clean = prompt.replace(/\n/g, " ").trim();
-    const title = clean.length > 65 ? clean.slice(0, 62) + "..." : clean;
+    const title = ensureDeerEmojiPrefix(clean.length > 65 ? clean.slice(0, 62) + "..." : clean);
     const body = [
       "## Summary",
       "",

--- a/test/finalize.test.ts
+++ b/test/finalize.test.ts
@@ -1,0 +1,20 @@
+import { test, expect, describe } from "bun:test";
+import { ensureDeerEmojiPrefix } from "../src/git/finalize";
+
+describe("ensureDeerEmojiPrefix", () => {
+  test("adds deer emoji to plain title", () => {
+    expect(ensureDeerEmojiPrefix("Fix login redirect loop")).toBe("🦌 Fix login redirect loop");
+  });
+
+  test("does not double-add deer emoji", () => {
+    expect(ensureDeerEmojiPrefix("🦌 Fix login redirect loop")).toBe("🦌 Fix login redirect loop");
+  });
+
+  test("handles empty string", () => {
+    expect(ensureDeerEmojiPrefix("")).toBe("🦌 ");
+  });
+
+  test("handles title that already starts with emoji and space", () => {
+    expect(ensureDeerEmojiPrefix("🦌 Add user search endpoint")).toBe("🦌 Add user search endpoint");
+  });
+});


### PR DESCRIPTION
## Summary

All PRs created by deer are now automatically prefixed with a 🦌 emoji. This makes it easy to identify deer-created PRs in GitHub's PR list at a glance.

## Changes

- Added `ensureDeerEmojiPrefix()` utility in `src/git/finalize.ts` that idempotently prepends `🦌 ` to PR titles
- Applied the prefix in both the Claude-generated and fallback title code paths
- Added `test/finalize.test.ts` with 4 tests covering normal, idempotent, empty, and pre-prefixed cases

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.