### PR TITLE
Add 'r' refresh command to re-acquire agent state

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -11,7 +11,7 @@ import { createPullRequest, cleanupWorktree } from "./git/finalize";
 import type { CreatePRResult } from "./git/finalize";
 import { launchSandbox, isTmuxSessionDead, captureTmuxPane } from "./sandbox/index";
 import type { SandboxSession } from "./sandbox/index";
-import { generateTaskId } from "./task";
+import { generateTaskId, dataDir } from "./task";
 import type { DeerConfig } from "./config";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -277,6 +277,35 @@ export async function createAgentPR(
     baseBranch,
     prompt,
   });
+}
+
+/**
+ * Try to re-acquire a handle for a previously-running agent.
+ *
+ * Checks if the expected tmux session (`deer-<taskId>`) is still alive and
+ * returns a reconstructed handle if so. Returns null if the session is dead
+ * or has already exited.
+ */
+export async function tryReacquireAgent(taskId: string): Promise<AgentHandle | null> {
+  const sessionName = `deer-${taskId}`;
+  const worktreePath = join(dataDir(), "tasks", taskId, "worktree");
+  const branch = `deer/${taskId}`;
+
+  const dead = await isTmuxSessionDead(sessionName);
+  if (dead) return null;
+
+  return {
+    taskId,
+    sessionName,
+    worktreePath,
+    branch,
+    async kill() {
+      await Bun.spawn(["tmux", "kill-session", "-t", sessionName], {
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exited;
+    },
+  };
 }
 
 /**

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,13 +1,13 @@
 import { Box, Text, useInput, useApp, useStdout } from "ink";
 import { Spinner } from "@inkjs/ui";
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { loadHistory, upsertHistory, removeFromHistory } from "./task";
+import { loadHistory, upsertHistory, removeFromHistory, dataDir } from "./task";
 import type { PersistedTask } from "./task";
 import { loadConfig } from "./config";
 import type { DeerConfig } from "./config";
 import { transition, availableActions, resolveKeypress, ACTION_BINDINGS } from "./state-machine";
 import type { AgentState as AgentStatus } from "./state-machine";
-import { startAgent, destroyAgent, createAgentPR } from "./agent";
+import { startAgent, destroyAgent, createAgentPR, tryReacquireAgent } from "./agent";
 import type { AgentHandle } from "./agent";
 import { isTmuxSessionDead, captureTmuxPane } from "./sandbox/index";
 import { detectRepo } from "./git/worktree";
@@ -541,79 +541,18 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     return () => clearInterval(interval);
   }, []);
 
-  // ── Spawn agent ───────────────────────────────────────────────────
+  // ── Poll agent to completion ───────────────────────────────────────
 
-  const spawnAgent = useCallback(async (prompt: string, baseBranch?: string) => {
-    if (!prompt.trim()) return;
-    if (preflight && !preflight.ok) return;
-
-    const config = configRef.current;
-    if (!config) return;
-
-    const id = nextId.current++;
-    const effectiveBranch = baseBranch ?? baseBranchRef.current;
-    const agent = createAgentState({
-      id,
-      prompt: prompt.trim(),
-      baseBranch: effectiveBranch,
-    });
-
-    const abortController = new AbortController();
-    agent.abortController = abortController;
-
-    // Start elapsed timer
-    agent.timer = setInterval(() => {
-      agent.elapsed++;
-      setAgents((prev) => [...prev]);
-    }, 1000);
-
-    setAgents((prev) => [...prev, agent]);
-
+  // Runs the polling loop for an agent that already has a live tmux session.
+  // Handles idle detection, log capture, and final state transition.
+  const pollAgentToCompletion = useCallback(async (
+    agent: AgentState,
+    handle: AgentHandle,
+    abortController: AbortController,
+  ): Promise<void> => {
+    let lastPaneSnapshot = "";
+    let unchangedCount = 0;
     try {
-      // Phase 1: Start the sandboxed agent
-      appendLog(agent, "[setup] Creating worktree and sandbox...");
-      agent.lastActivity = "Setting up sandbox...";
-      setAgents((prev) => [...prev]);
-
-      const handle = await startAgent({
-        repoPath: cwd,
-        prompt: prompt.trim(),
-        baseBranch: effectiveBranch,
-        config,
-        model: MODEL,
-        onStatus: (status) => {
-          const detail = "message" in status ? status.message : status.phase;
-          appendLog(agent, `[setup] ${detail}`);
-          agent.lastActivity = detail;
-          setAgents((prev) => [...prev]);
-        },
-      });
-
-      agent.handle = handle;
-      agent.taskId = handle.taskId;
-
-      // Persist immediately so the task survives if deer closes
-      await upsertHistory(cwd, {
-        taskId: agent.taskId,
-        prompt: agent.prompt,
-        status: "running",
-        createdAt: new Date().toISOString(),
-        completedAt: null,
-        elapsed: 0,
-        prUrl: null,
-        finalBranch: null,
-        error: null,
-            lastActivity: "",
-      });
-
-      agent.status = transition(agent.status, "SETUP_COMPLETE") ?? agent.status;
-      appendLog(agent, `[running] Claude started in tmux session: ${handle.sessionName}`);
-      agent.lastActivity = "Claude running...";
-      setAgents((prev) => [...prev]);
-
-      // Phase 2: Poll for completion (process exit or idle detection)
-      let lastPaneSnapshot = "";
-      let unchangedCount = 0;
       while (true) {
         await Bun.sleep(POLL_MS);
         if (abortController.signal.aborted) return;
@@ -669,7 +608,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       // Process exited — mark completed, user decides what to do next
       agent.idle = false;
       agent.status = "completed";
-      agent.result = { finalBranch: handle.branch, prUrl: "" };
+      agent.result = { finalBranch: handle.branch, prUrl: agent.result?.prUrl ?? "" };
       agent.lastActivity = "Task complete — press p to create PR, ⏎ to attach";
     } catch (err) {
       if (!abortController.signal.aborted) {
@@ -683,7 +622,94 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       await saveToHistory(agent, cwd);
       setAgents((prev) => [...prev]);
     }
-  }, [cwd, preflight]);
+  }, [cwd]);
+
+  // ── Spawn agent ───────────────────────────────────────────────────
+
+  const spawnAgent = useCallback(async (prompt: string, baseBranch?: string) => {
+    if (!prompt.trim()) return;
+    if (preflight && !preflight.ok) return;
+
+    const config = configRef.current;
+    if (!config) return;
+
+    const id = nextId.current++;
+    const effectiveBranch = baseBranch ?? baseBranchRef.current;
+    const agent = createAgentState({
+      id,
+      prompt: prompt.trim(),
+      baseBranch: effectiveBranch,
+    });
+
+    const abortController = new AbortController();
+    agent.abortController = abortController;
+
+    // Start elapsed timer
+    agent.timer = setInterval(() => {
+      agent.elapsed++;
+      setAgents((prev) => [...prev]);
+    }, 1000);
+
+    setAgents((prev) => [...prev, agent]);
+
+    let handle: AgentHandle;
+    try {
+      // Phase 1: Start the sandboxed agent
+      appendLog(agent, "[setup] Creating worktree and sandbox...");
+      agent.lastActivity = "Setting up sandbox...";
+      setAgents((prev) => [...prev]);
+
+      handle = await startAgent({
+        repoPath: cwd,
+        prompt: prompt.trim(),
+        baseBranch: effectiveBranch,
+        config,
+        model: MODEL,
+        onStatus: (status) => {
+          const detail = "message" in status ? status.message : status.phase;
+          appendLog(agent, `[setup] ${detail}`);
+          agent.lastActivity = detail;
+          setAgents((prev) => [...prev]);
+        },
+      });
+
+      agent.handle = handle;
+      agent.taskId = handle.taskId;
+
+      // Persist immediately so the task survives if deer closes
+      await upsertHistory(cwd, {
+        taskId: agent.taskId,
+        prompt: agent.prompt,
+        status: "running",
+        createdAt: new Date().toISOString(),
+        completedAt: null,
+        elapsed: 0,
+        prUrl: null,
+        finalBranch: null,
+        error: null,
+        lastActivity: "",
+      });
+
+      agent.status = transition(agent.status, "SETUP_COMPLETE") ?? agent.status;
+      appendLog(agent, `[running] Claude started in tmux session: ${handle.sessionName}`);
+      agent.lastActivity = "Claude running...";
+      setAgents((prev) => [...prev]);
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        agent.status = transition(agent.status, "ERROR") ?? "failed";
+        agent.error = err instanceof Error ? err.message : String(err);
+        agent.lastActivity = truncate(agent.error, 120);
+      }
+      if (agent.timer) clearInterval(agent.timer);
+      agent.timer = null;
+      await saveToHistory(agent, cwd);
+      setAgents((prev) => [...prev]);
+      return;
+    }
+
+    // Phase 2: Poll for completion (process exit or idle detection)
+    await pollAgentToCompletion(agent, handle, abortController);
+  }, [cwd, preflight, pollAgentToCompletion]);
 
   // ── Kill agent ────────────────────────────────────────────────────
 
@@ -756,6 +782,99 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     setAgents((prev) => [...prev]);
   }, [cwd]);
 
+
+  // ── Refresh agent ─────────────────────────────────────────────────
+
+  // Re-acquire a task's tmux session and worktree, resuming polling if alive.
+  // For failed/cancelled tasks with no live session, re-spawns a new agent.
+  const refreshAgent = useCallback(async (agent: AgentState) => {
+    appendLog(agent, "[refresh] Checking agent state...");
+    agent.lastActivity = "Refreshing...";
+    setAgents((prev) => [...prev]);
+
+    const handle = await tryReacquireAgent(agent.taskId);
+
+    if (handle && (agent.status === "interrupted" || agent.status === "running")) {
+      // Session is still alive — re-acquire handle and resume polling
+      agent.handle = handle;
+      agent.status = "running";
+      agent.lastActivity = `Reconnected to session ${handle.sessionName}`;
+      appendLog(agent, `[refresh] Reconnected to tmux session: ${handle.sessionName}`);
+
+      const abortController = new AbortController();
+      agent.abortController = abortController;
+
+      if (!agent.timer) {
+        agent.timer = setInterval(() => {
+          agent.elapsed++;
+          setAgents((prev) => [...prev]);
+        }, 1000);
+      }
+
+      await upsertHistory(cwd, {
+        taskId: agent.taskId,
+        prompt: agent.prompt,
+        status: "running",
+        createdAt: new Date(Date.now() - agent.elapsed * 1000).toISOString(),
+        completedAt: null,
+        elapsed: agent.elapsed,
+        prUrl: agent.result?.prUrl ?? null,
+        finalBranch: agent.result?.finalBranch ?? null,
+        error: null,
+        lastActivity: agent.lastActivity,
+      });
+      setAgents((prev) => [...prev]);
+
+      await pollAgentToCompletion(agent, handle, abortController);
+      return;
+    }
+
+    if (handle) {
+      // Session alive but agent is already in a terminal state — report it
+      appendLog(agent, `[refresh] Session ${handle.sessionName} is still alive`);
+      agent.lastActivity = `Session still running: ${handle.sessionName}`;
+      setAgents((prev) => [...prev]);
+      return;
+    }
+
+    // No live session found
+    if (agent.status === "interrupted") {
+      appendLog(agent, "[refresh] Session not found — task may have completed while deer was closed");
+      agent.lastActivity = "Session no longer running";
+      setAgents((prev) => [...prev]);
+      return;
+    }
+
+    if (agent.status === "failed" || agent.status === "cancelled") {
+      // Re-spawn with the same prompt
+      appendLog(agent, "[refresh] Re-spawning agent...");
+      setAgents((prev) => [...prev]);
+      spawnAgent(agent.prompt, agent.baseBranch);
+      return;
+    }
+
+    if (agent.status === "running") {
+      // Session ended unexpectedly while deer was polling — treat as completed
+      appendLog(agent, "[refresh] Session not found — process exited");
+      agent.idle = false;
+      agent.status = "completed";
+      agent.result = {
+        finalBranch: agent.handle?.branch ?? `deer/${agent.taskId}`,
+        prUrl: agent.result?.prUrl ?? "",
+      };
+      agent.lastActivity = "Task complete — press p to create PR, ⏎ to attach";
+      if (agent.timer) clearInterval(agent.timer);
+      agent.timer = null;
+      await saveToHistory(agent, cwd);
+      setAgents((prev) => [...prev]);
+      return;
+    }
+
+    // Completed/teardown/setup — nothing to re-acquire
+    appendLog(agent, "[refresh] State refreshed");
+    agent.lastActivity = `Refreshed (${agent.status})`;
+    setAgents((prev) => [...prev]);
+  }, [cwd, spawnAgent, pollAgentToCompletion]);
 
   // ── Keyboard input ────────────────────────────────────────────────
 
@@ -860,8 +979,8 @@ export default function Dashboard({ cwd }: { cwd: string }) {
           case "toggle_logs":
             setLogExpanded((prev) => !prev);
             break;
-          case "retry":
-            spawnAgent(agent.prompt);
+          case "refresh":
+            refreshAgent(agent);
             break;
         }
       }

--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -29,7 +29,7 @@ export type AgentAction =
   | "kill"
   | "delete"
   | "toggle_logs"
-  | "retry";
+  | "refresh";
 
 export interface AgentContext {
   status: AgentState;
@@ -68,13 +68,13 @@ export function transition(current: AgentState, event: AgentEvent): AgentState |
 // ── Action Map per State ─────────────────────────────────────────────
 
 const ACTIONS_BY_STATE: Record<AgentState, AgentAction[]> = {
-  setup:       ["kill", "toggle_logs"],
-  running:     ["attach", "kill", "toggle_logs"],
-  teardown:    ["toggle_logs"],
-  completed:   ["attach", "create_pr", "open_pr", "delete", "toggle_logs"],
-  failed:      ["retry", "delete", "toggle_logs"],
-  cancelled:   ["delete", "toggle_logs"],
-  interrupted: ["delete", "toggle_logs"],
+  setup:       ["kill", "toggle_logs", "refresh"],
+  running:     ["attach", "kill", "toggle_logs", "refresh"],
+  teardown:    ["toggle_logs", "refresh"],
+  completed:   ["attach", "create_pr", "open_pr", "delete", "toggle_logs", "refresh"],
+  failed:      ["delete", "toggle_logs", "refresh"],
+  cancelled:   ["delete", "toggle_logs", "refresh"],
+  interrupted: ["delete", "toggle_logs", "refresh"],
 };
 
 // ── Action Bindings ──────────────────────────────────────────────────
@@ -86,7 +86,7 @@ export const ACTION_BINDINGS: Record<AgentAction, ActionBinding> = {
   kill:         { keyDisplay: "x", label: "kill" },
   delete:       { keyDisplay: "⌫", label: "delete" },
   toggle_logs:  { keyDisplay: "l", label: "logs" },
-  retry:        { keyDisplay: "r", label: "retry" },
+  refresh:      { keyDisplay: "r", label: "refresh" },
 };
 
 // ── Runtime Filtering ────────────────────────────────────────────────
@@ -158,7 +158,7 @@ export function resolveKeypress(
   const charMap: Record<string, AgentAction> = {
     x: "kill",
     l: "toggle_logs",
-    r: "retry",
+    r: "refresh",
   };
 
   const action = charMap[input];

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -103,9 +103,12 @@ describe("availableActions", () => {
     expect(actions).toContain("toggle_logs");
   });
 
-  test("teardown state has only toggle_logs", () => {
+  test("teardown state has toggle_logs and refresh", () => {
     const actions = availableActions(baseCtx({ status: "teardown" }));
-    expect(actions).toEqual(["toggle_logs"]);
+    expect(actions).toContain("toggle_logs");
+    expect(actions).toContain("refresh");
+    expect(actions).not.toContain("attach");
+    expect(actions).not.toContain("kill");
   });
 
   test("completed state has attach, create_pr, delete, toggle_logs", () => {
@@ -162,20 +165,20 @@ describe("availableActions", () => {
     expect(actions).toContain("delete");
   });
 
-  test("failed state has retry, delete, toggle_logs", () => {
+  test("failed state has refresh, delete, toggle_logs", () => {
     const actions = availableActions(baseCtx({
       status: "failed",
       hasHandle: true,
     }));
-    expect(actions).toContain("retry");
+    expect(actions).toContain("refresh");
     expect(actions).toContain("delete");
     expect(actions).toContain("toggle_logs");
   });
 
-  test("retry is not available in non-failed states", () => {
-    for (const status of ["setup", "running", "teardown", "completed", "cancelled", "interrupted"] as const) {
+  test("refresh is available in all states", () => {
+    for (const status of ["setup", "running", "teardown", "completed", "failed", "cancelled", "interrupted"] as const) {
       const actions = availableActions(baseCtx({ status }));
-      expect(actions).not.toContain("retry");
+      expect(actions).toContain("refresh");
     }
   });
 
@@ -264,12 +267,22 @@ describe("resolveKeypress", () => {
     expect(resolveKeypress("z", {}, ["kill", "toggle_logs"])).toBeNull();
   });
 
-  test("resolves 'r' to retry when available", () => {
-    expect(resolveKeypress("r", {}, ["retry", "delete"])).toBe("retry");
+  test("resolves 'r' to refresh when available", () => {
+    expect(resolveKeypress("r", {}, ["refresh", "delete"])).toBe("refresh");
   });
 
-  test("does not resolve 'r' when retry is unavailable", () => {
-    expect(resolveKeypress("r", {}, ["delete", "toggle_logs"])).toBeNull();
+  test("resolves 'r' to refresh in all states", () => {
+    for (const status of ["setup", "running", "teardown", "completed", "failed", "cancelled", "interrupted"] as const) {
+      const actions = availableActions({
+        status,
+        hasPrUrl: false,
+        hasFinalBranch: false,
+        hasHandle: false,
+        isIdle: false,
+        prState: null,
+      });
+      expect(resolveKeypress("r", {}, actions)).toBe("refresh");
+    }
   });
 
   test("resolves 'p' to create_pr when available", () => {
@@ -294,7 +307,7 @@ describe("resolveKeypress", () => {
 describe("ACTION_BINDINGS", () => {
   test("every action has a keyDisplay and label", () => {
     const actions: AgentAction[] = [
-      "attach", "create_pr", "open_pr", "kill", "delete", "toggle_logs", "retry",
+      "attach", "create_pr", "open_pr", "kill", "delete", "toggle_logs", "refresh",
     ];
     for (const action of actions) {
       const binding = ACTION_BINDINGS[action];


### PR DESCRIPTION
## Summary

Replaces the narrow `retry` action (only available on failed tasks) with a universal `refresh` action available in all task states. The refresh command attempts to re-acquire a previously-running agent's tmux session and worktree, resuming polling if the session is still alive.

## Changes

- Added `tryReacquireAgent()` in `agent.ts` — checks if `deer-<taskId>` tmux session is still alive and reconstructs an `AgentHandle` if so
- Extracted `pollAgentToCompletion()` callback in `dashboard.tsx` so it can be reused by both `spawnAgent` and `refreshAgent`
- Added `refreshAgent()` in `dashboard.tsx` with state-aware behaviour:
  - **running/interrupted + live session**: reconnects and resumes polling
  - **running + dead session**: marks task as completed
  - **interrupted + dead session**: reports session no longer running
  - **failed/cancelled**: re-spawns a new agent with the same prompt
  - **other terminal states**: reports refreshed status
- Renamed `retry` → `refresh` throughout `state-machine.ts` and added `refresh` to all states (was only on `failed`)
- Fixed a bug where a `null` PR state would overwrite a previously-known PR state during polling
- Updated all affected tests

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.