### PR TITLE
🦌 Allow deleting tasks regardless of current state

### DIFF
--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -68,9 +68,9 @@ export function transition(current: AgentState, event: AgentEvent): AgentState |
 // ── Action Map per State ─────────────────────────────────────────────
 
 const ACTIONS_BY_STATE: Record<AgentState, AgentAction[]> = {
-  setup:       ["kill", "toggle_logs"],
-  running:     ["attach", "kill", "toggle_logs"],
-  teardown:    ["toggle_logs"],
+  setup:       ["kill", "delete", "toggle_logs"],
+  running:     ["attach", "kill", "delete", "toggle_logs"],
+  teardown:    ["delete", "toggle_logs"],
   completed:   ["attach", "create_pr", "open_pr", "delete", "toggle_logs"],
   failed:      ["retry", "delete", "toggle_logs"],
   cancelled:   ["delete", "toggle_logs"],
@@ -111,7 +111,7 @@ export function availableActions(ctx: AgentContext): AgentAction[] {
       case "open_pr":
         return ctx.hasPrUrl;
       case "delete":
-        return ctx.prState !== "open";
+        return true;
       default:
         return true;
     }

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -88,24 +88,27 @@ describe("availableActions", () => {
     ...overrides,
   });
 
-  test("setup state has kill and toggle_logs", () => {
+  test("setup state has kill, delete and toggle_logs", () => {
     const actions = availableActions(baseCtx({ status: "setup" }));
     expect(actions).toContain("kill");
+    expect(actions).toContain("delete");
     expect(actions).toContain("toggle_logs");
     expect(actions).not.toContain("attach");
     expect(actions).not.toContain("open_pr");
   });
 
-  test("running state has attach, kill, toggle_logs", () => {
+  test("running state has attach, kill, delete, toggle_logs", () => {
     const actions = availableActions(baseCtx({ status: "running" }));
     expect(actions).toContain("attach");
     expect(actions).toContain("kill");
+    expect(actions).toContain("delete");
     expect(actions).toContain("toggle_logs");
   });
 
-  test("teardown state has only toggle_logs", () => {
+  test("teardown state has delete and toggle_logs", () => {
     const actions = availableActions(baseCtx({ status: "teardown" }));
-    expect(actions).toEqual(["toggle_logs"]);
+    expect(actions).toContain("delete");
+    expect(actions).toContain("toggle_logs");
   });
 
   test("completed state has attach, create_pr, delete, toggle_logs", () => {
@@ -142,14 +145,14 @@ describe("availableActions", () => {
     expect(actions).not.toContain("open_pr");
   });
 
-  test("completed state: delete blocked when prState is open", () => {
+  test("completed state: delete allowed when prState is open", () => {
     const actions = availableActions(baseCtx({
       status: "completed",
       hasPrUrl: true,
       hasFinalBranch: true,
       prState: "open",
     }));
-    expect(actions).not.toContain("delete");
+    expect(actions).toContain("delete");
   });
 
   test("completed state: delete allowed when prState is merged", () => {


### PR DESCRIPTION
## Summary

Previously, task deletion was restricted based on state and PR status — it was unavailable during `setup`, `running`, and `teardown` states, and blocked for `completed` tasks with an open PR. This change makes the delete action available in all states unconditionally.

## Changes

- Added `delete` action to `setup`, `running`, and `teardown` states in `ACTIONS_BY_STATE`
- Removed the `prState !== "open"` guard from the `delete` case in `availableActions`, always returning `true`
- Updated tests to reflect that delete is now available in all states, including with an open PR

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.