### PR TITLE
🦌 Show review emoji when PR exists and agent is idle

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -902,7 +902,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
                   {agent.creatingPr ? (
                     <Text color="blue">{UPLOAD_FRAMES[animTick % UPLOAD_FRAMES.length]}</Text>
                   ) : agent.idle ? (
-                    <Text>👋</Text>
+                    <Text>{agent.result?.prUrl ? "👀" : "👋"}</Text>
                   ) : agent.status === "running" ? (
                     <Spinner label="" />
                   ) : (


### PR DESCRIPTION
## Summary

When an agent is idle and a PR has already been created, show a 👀 emoji instead of the default 👋 wave emoji. This gives a clearer visual signal that the agent is waiting for review rather than just finished.

## Changes

- Replace static 👋 emoji with a conditional: show 👀 if `agent.result.prUrl` exists, otherwise 👋

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.