### PR TITLE
🦌 Fix Shift+Enter newline and restrict delete action

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -226,10 +226,12 @@ function PromptInput({
 
   // Handle Shift+Enter via the Kitty keyboard protocol escape sequence (\x1b[13;2u).
   // Standard terminals send the same \r byte for Enter and Shift+Enter, so Ink's
-  // useInput cannot distinguish them. Terminals supporting the Kitty protocol
-  // (kitty, WezTerm, foot, etc.) send a distinct sequence that we intercept here.
+  // useInput cannot distinguish them. We explicitly request the Kitty keyboard
+  // protocol (\x1b[>1u) so terminals that support it (kitty, WezTerm, foot, ghostty,
+  // xterm, etc.) send the distinct sequence. On cleanup we pop the mode (\x1b[<u).
   useEffect(() => {
     if (isDisabled) return;
+    process.stdout.write("\x1b[>1u");
     const handleData = (data: Buffer) => {
       if (data.toString() === "\x1b[13;2u") {
         const cur = cursorOffsetRef.current;
@@ -243,7 +245,10 @@ function PromptInput({
       }
     };
     process.stdin.on("data", handleData);
-    return () => { process.stdin.off("data", handleData); };
+    return () => {
+      process.stdin.off("data", handleData);
+      process.stdout.write("\x1b[<u");
+    };
   }, [isDisabled]);
 
   useInput(


### PR DESCRIPTION
## Summary

Fixes Shift+Enter not inserting newlines in the prompt input by explicitly enabling the Kitty keyboard protocol on mount (`\x1b[>1u`) and disabling it on cleanup (`\x1b[<u`). Previously the protocol was never activated, so terminals never sent the distinct escape sequence.

Also restricts the delete action: it is no longer available in `setup`, `running`, or `teardown` states, and is blocked in `completed`/`failed`/`cancelled` states when the PR is still open.

## Changes

- Enable Kitty keyboard protocol on `PromptInput` mount; pop mode on unmount
- Remove `delete` action from `setup`, `running`, and `teardown` state action maps
- Block `delete` action when `prState === "open"`
- Always show 👋 for idle agents (drop 👀 variant for agents with a PR URL)
- Update tests to match new action availability rules

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.