### PR TITLE
🦌 Fix security guard warning text being mangled in dashboard

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -954,7 +954,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       {configAlerts.length > 0 && (
         <Box flexDirection="column" paddingX={1}>
           <Text color="red" bold>
-            {configAlerts.some((a) => a.severity === "critical") ? "!! SECURITY" : " ! WARNING"}: ~/.claude modified while agents running
+            {`${configAlerts.some((a) => a.severity === "critical") ? "!! SECURITY" : " ! WARNING"}: ~/.claude modified while agents running`}
           </Text>
           {configAlerts.slice(-3).map((alert, i) => (
             <Text key={i} color={alert.severity === "critical" ? "red" : "yellow"}>


### PR DESCRIPTION
## Summary

The security warning text displayed when `~/.claude` is modified while agents are running was being mangled by JSX/Ink's text rendering, producing output like `~/.claude.jsonied while agents running`. The fix wraps the expression in a template literal string to ensure the full string is passed as a single text node.

## Changes

- Wrap the security warning `Text` content in a template literal to prevent JSX from splitting the expression and adjacent string literal into separate text nodes

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.