### PR TITLE
🦌 Add 'u' shortcut to update an existing PR

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,7 +7,7 @@
 
 import { join, resolve } from "node:path";
 import { createWorktree, removeWorktree } from "./git/worktree";
-import { createPullRequest, cleanupWorktree } from "./git/finalize";
+import { createPullRequest, updatePullRequest, cleanupWorktree } from "./git/finalize";
 import type { CreatePRResult } from "./git/finalize";
 import { launchSandbox, isTmuxSessionDead, captureTmuxPane } from "./sandbox/index";
 import type { SandboxSession, SandboxRuntime } from "./sandbox/index";
@@ -218,6 +218,26 @@ export async function createAgentPR(
     branch: handle.branch,
     baseBranch,
     prompt,
+  });
+}
+
+/**
+ * Push new commits and update the title/body of an existing PR.
+ */
+export async function updateAgentPR(
+  handle: AgentHandle,
+  repoPath: string,
+  baseBranch: string,
+  prompt: string,
+  prUrl: string,
+): Promise<void> {
+  return updatePullRequest({
+    repoPath,
+    worktreePath: handle.worktreePath,
+    finalBranch: handle.branch,
+    baseBranch,
+    prompt,
+    prUrl,
   });
 }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -7,7 +7,7 @@ import { loadConfig } from "./config";
 import type { DeerConfig } from "./config";
 import { transition, availableActions, resolveKeypress, ACTION_BINDINGS } from "./state-machine";
 import type { AgentState as AgentStatus } from "./state-machine";
-import { startAgent, destroyAgent, deleteTask, createAgentPR } from "./agent";
+import { startAgent, destroyAgent, deleteTask, createAgentPR, updateAgentPR } from "./agent";
 import { isTmuxSessionDead, captureTmuxPane } from "./sandbox/index";
 import { resolveRuntime } from "./sandbox/resolve";
 import { detectRepo } from "./git/worktree";
@@ -757,6 +757,31 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   }, [cwd]);
 
 
+  const updatePr = useCallback(async (agent: AgentState) => {
+    if (!agent.handle || !agent.result?.prUrl) return;
+
+    agent.creatingPr = true;
+    agent.lastActivity = "Updating PR...";
+    setAgents((prev) => [...prev]);
+
+    try {
+      await updateAgentPR(
+        agent.handle,
+        cwd,
+        agent.baseBranch,
+        agent.prompt,
+        agent.result.prUrl,
+      );
+      agent.lastActivity = "PR updated";
+    } catch (err) {
+      agent.lastActivity = `PR update failed: ${err instanceof Error ? err.message : String(err)}`;
+    } finally {
+      agent.creatingPr = false;
+    }
+    await saveToHistory(agent, cwd);
+    setAgents((prev) => [...prev]);
+  }, [cwd]);
+
   // ── Keyboard input ────────────────────────────────────────────────
 
   useInput((input, key) => {
@@ -895,6 +920,9 @@ export default function Dashboard({ cwd }: { cwd: string }) {
             break;
           case "create_pr":
             createPr(agent);
+            break;
+          case "update_pr":
+            updatePr(agent);
             break;
           case "open_pr":
             if (agent.result?.prUrl) openUrl(agent.result.prUrl);

--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -17,6 +17,17 @@ export interface CreatePROptions {
   prompt: string;
 }
 
+export interface UpdatePROptions {
+  repoPath: string;
+  worktreePath: string;
+  /** Already-finalized branch name, e.g. "deer/fix-login-bug" */
+  finalBranch: string;
+  baseBranch: string;
+  prompt: string;
+  /** @example "https://github.com/org/repo/pull/42" */
+  prUrl: string;
+}
+
 interface PRMetadata {
   branchName: string;
   title: string;
@@ -167,6 +178,39 @@ export async function createPullRequest(options: CreatePROptions): Promise<Creat
     prUrl: prResult.stdout.toString().trim(),
     finalBranch,
   };
+}
+
+/**
+ * Update an existing PR: commit any new changes, push, and regenerate the
+ * PR title and body from the latest diff.
+ */
+export async function updatePullRequest(options: UpdatePROptions): Promise<void> {
+  const { repoPath, worktreePath, finalBranch, baseBranch, prompt, prUrl } = options;
+
+  // Remove deer internal files before staging
+  await Bun.$`rm -rf ${worktreePath}/.deer-claude-config ${worktreePath}/.deer-prompt`.quiet().nothrow();
+
+  // Stage and commit any uncommitted changes
+  await Bun.$`git -C ${worktreePath} add -A`.quiet();
+  const status = await Bun.$`git -C ${worktreePath} status --porcelain`.quiet();
+  if (status.stdout.toString().trim().length > 0) {
+    await Bun.$`git -C ${worktreePath} commit -m "deer: uncommitted changes from agent session"`.quiet();
+  }
+
+  // Push the branch
+  const pushResult = await Bun.$`git -C ${worktreePath} push origin ${finalBranch}`.quiet().nothrow();
+  if (pushResult.exitCode !== 0) {
+    throw new Error(`Push failed: ${pushResult.stderr.toString().trim()}`);
+  }
+
+  // Regenerate PR metadata from the updated diff
+  const metadata = await generatePRMetadata(worktreePath, baseBranch, prompt);
+
+  // Update the PR title and body
+  const editResult = await Bun.$`gh pr edit ${prUrl} --title ${metadata.title} --body ${metadata.body}`.cwd(repoPath).quiet().nothrow();
+  if (editResult.exitCode !== 0) {
+    throw new Error(`PR update failed: ${editResult.stderr.toString().trim()}`);
+  }
 }
 
 /**

--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -26,6 +26,7 @@ export type AgentAction =
   | "attach"
   | "create_pr"
   | "open_pr"
+  | "update_pr"
   | "kill"
   | "delete"
   | "toggle_logs"
@@ -71,7 +72,7 @@ const ACTIONS_BY_STATE: Record<AgentState, AgentAction[]> = {
   setup:       ["kill", "delete", "toggle_logs"],
   running:     ["attach", "kill", "delete", "toggle_logs"],
   teardown:    ["delete", "toggle_logs"],
-  completed:   ["attach", "create_pr", "open_pr", "delete", "toggle_logs"],
+  completed:   ["attach", "create_pr", "open_pr", "update_pr", "delete", "toggle_logs"],
   failed:      ["retry", "delete", "toggle_logs"],
   cancelled:   ["delete", "toggle_logs"],
   interrupted: ["delete", "toggle_logs"],
@@ -83,6 +84,7 @@ export const ACTION_BINDINGS: Record<AgentAction, ActionBinding> = {
   attach:       { keyDisplay: "⏎", label: "attach" },
   create_pr:    { keyDisplay: "p", label: "create PR" },
   open_pr:      { keyDisplay: "p", label: "open PR" },
+  update_pr:    { keyDisplay: "u", label: "update PR" },
   kill:         { keyDisplay: "x", label: "kill" },
   delete:       { keyDisplay: "⌫", label: "delete" },
   toggle_logs:  { keyDisplay: "l", label: "logs" },
@@ -98,9 +100,9 @@ export const ACTION_BINDINGS: Record<AgentAction, ActionBinding> = {
  */
 export function availableActions(ctx: AgentContext): AgentAction[] {
   const base = [...ACTIONS_BY_STATE[ctx.status]];
-  // Idle agents can create PRs (Claude is alive but waiting for input)
+  // Idle agents can create or update PRs (Claude is alive but waiting for input)
   if (ctx.isIdle && !base.includes("create_pr")) {
-    base.push("create_pr", "open_pr");
+    base.push("create_pr", "open_pr", "update_pr");
   }
   return base.filter((action) => {
     switch (action) {
@@ -109,6 +111,8 @@ export function availableActions(ctx: AgentContext): AgentAction[] {
       case "create_pr":
         return ctx.hasFinalBranch && !ctx.hasPrUrl;
       case "open_pr":
+        return ctx.hasPrUrl;
+      case "update_pr":
         return ctx.hasPrUrl;
       case "delete":
         return true;
@@ -159,6 +163,7 @@ export function resolveKeypress(
     x: "kill",
     l: "toggle_logs",
     r: "retry",
+    u: "update_pr",
   };
 
   const action = charMap[input];

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -292,12 +292,61 @@ describe("resolveKeypress", () => {
   });
 });
 
+// ── update_pr action tests ────────────────────────────────────────────
+
+describe("update_pr action", () => {
+  const baseCtx = (overrides: Partial<AgentContext>): AgentContext => ({
+    status: "completed",
+    hasPrUrl: true,
+    hasFinalBranch: true,
+    hasHandle: true,
+    isIdle: false,
+    prState: "open",
+    ...overrides,
+  });
+
+  test("update_pr available in completed state when PR exists", () => {
+    const actions = availableActions(baseCtx({ hasPrUrl: true }));
+    expect(actions).toContain("update_pr");
+  });
+
+  test("update_pr not available in completed state when no PR", () => {
+    const actions = availableActions(baseCtx({ hasPrUrl: false }));
+    expect(actions).not.toContain("update_pr");
+  });
+
+  test("update_pr available in idle running state when PR exists", () => {
+    const actions = availableActions(baseCtx({ status: "running", isIdle: true, hasPrUrl: true }));
+    expect(actions).toContain("update_pr");
+  });
+
+  test("update_pr not available in idle running state when no PR", () => {
+    const actions = availableActions(baseCtx({ status: "running", isIdle: true, hasPrUrl: false }));
+    expect(actions).not.toContain("update_pr");
+  });
+
+  test("update_pr not available in non-terminal non-idle states", () => {
+    for (const status of ["setup", "teardown", "cancelled", "interrupted"] as const) {
+      const actions = availableActions(baseCtx({ status, hasPrUrl: true }));
+      expect(actions).not.toContain("update_pr");
+    }
+  });
+
+  test("'u' key resolves to update_pr when available", () => {
+    expect(resolveKeypress("u", {}, ["update_pr", "open_pr", "delete"])).toBe("update_pr");
+  });
+
+  test("'u' key returns null when update_pr is not available", () => {
+    expect(resolveKeypress("u", {}, ["open_pr", "delete"])).toBeNull();
+  });
+});
+
 // ── ACTION_BINDINGS tests ────────────────────────────────────────────
 
 describe("ACTION_BINDINGS", () => {
   test("every action has a keyDisplay and label", () => {
     const actions: AgentAction[] = [
-      "attach", "create_pr", "open_pr", "kill", "delete", "toggle_logs", "retry",
+      "attach", "create_pr", "open_pr", "update_pr", "kill", "delete", "toggle_logs", "retry",
     ];
     for (const action of actions) {
       const binding = ACTION_BINDINGS[action];


### PR DESCRIPTION
## Summary

Adds the ability to update a pull request that has already been created. When an agent is in the `completed` or idle `running` state and a PR URL exists, pressing `u` will push any new commits, regenerate the PR title/body from the latest diff, and update the PR via `gh pr edit`.

## Changes

- `src/git/finalize.ts`: Added `updatePullRequest()` function and `UpdatePROptions` interface — stages/commits uncommitted changes, pushes the branch, regenerates PR metadata, and calls `gh pr edit`
- `src/agent.ts`: Added `updateAgentPR()` wrapper that delegates to `updatePullRequest()`
- `src/state-machine.ts`: Added `update_pr` action type, bound to `u` key; available in `completed` state and idle `running` state when `hasPrUrl` is true
- `src/dashboard.tsx`: Added `updatePr` callback and wired `update_pr` case in the keypress handler
- `test/state-machine.test.ts`: Added test suite for `update_pr` availability across states and key resolution

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.