### PR TITLE
🦌 Remove dead code from agent, worktree, and config guard

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -131,10 +131,6 @@ export async function startAgent(options: AgentRunOptions): Promise<AgentHandle>
   await Bun.$`git -C ${worktree.worktreePath} config user.name "deer-agent"`.quiet();
   await Bun.$`git -C ${worktree.worktreePath} config user.email "deer@noreply"`.quiet();
 
-  // Write the prompt to a file in the worktree so Claude can read it
-  const promptPath = `${worktree.worktreePath}/.deer-prompt`;
-  await Bun.write(promptPath, prompt);
-
   // Build the Claude command — interactive mode (no -p) so users can
   // attach to the tmux session and observe/intervene.
   const claudeCmd = [
@@ -160,9 +156,6 @@ export async function startAgent(options: AgentRunOptions): Promise<AgentHandle>
     await removeWorktree(repoPath, worktree.worktreePath).catch(() => {});
     throw err;
   }
-
-  // Clean up the prompt file (it's already been passed to Claude)
-  await Bun.$`rm -f ${promptPath}`.quiet().nothrow();
 
   // Dismiss the --dangerously-skip-permissions confirmation dialog.
   // The dialog defaults to "1. No, exit" — send Down then Enter

--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -126,9 +126,6 @@ ${truncatedDiff}`;
 export async function createPullRequest(options: CreatePROptions): Promise<CreatePRResult> {
   const { repoPath, worktreePath, branch, baseBranch, prompt } = options;
 
-  // Remove deer internal files before staging
-  await Bun.$`rm -rf ${worktreePath}/.deer-claude-config ${worktreePath}/.deer-prompt`.quiet().nothrow();
-
   // Stage and commit any uncommitted changes
   await Bun.$`git -C ${worktreePath} add -A`.quiet();
   const status = await Bun.$`git -C ${worktreePath} status --porcelain`.quiet();

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -10,7 +10,6 @@ export interface WorktreeInfo {
 
 export interface RepoInfo {
   repoPath: string;
-  remote: string;
   defaultBranch: string;
 }
 
@@ -30,16 +29,6 @@ export async function detectRepo(startDir: string): Promise<RepoInfo> {
 
   const repoPath = result.stdout.toString().trim();
 
-  // Get remote URL
-  const remoteResult =
-    await Bun.$`git -C ${repoPath} remote get-url origin`.quiet();
-  if (remoteResult.exitCode !== 0) {
-    throw new Error(
-      `No 'origin' remote found in ${repoPath}: ${remoteResult.stderr.toString()}`
-    );
-  }
-  const remote = remoteResult.stdout.toString().trim();
-
   // Get default branch
   const branchResult =
     await Bun.$`git -C ${repoPath} symbolic-ref refs/remotes/origin/HEAD`.quiet().nothrow();
@@ -58,7 +47,7 @@ export async function detectRepo(startDir: string): Promise<RepoInfo> {
     defaultBranch = mainCheck.exitCode === 0 ? "main" : "master";
   }
 
-  return { repoPath, remote, defaultBranch };
+  return { repoPath, defaultBranch };
 }
 
 /**

--- a/src/sandbox/claude-config-guard.ts
+++ b/src/sandbox/claude-config-guard.ts
@@ -27,8 +27,6 @@ export interface ConfigAlert {
 export interface ClaudeConfigGuard {
   /** Current unacknowledged alerts */
   alerts: ConfigAlert[];
-  /** Dismiss all current alerts */
-  acknowledge(): void;
   /** Stop watching */
   stop(): void;
 }
@@ -314,9 +312,6 @@ export async function startClaudeConfigGuard(
 
   return {
     alerts,
-    acknowledge() {
-      alerts.length = 0;
-    },
     stop() {
       stopped = true;
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -34,9 +34,7 @@ export interface SandboxOptions {
   extraWritePaths?: string[];
   /** Command + args to run inside the sandbox (default: interactive shell) */
   command: string[];
-  /** Sandbox runtime to use
-   * @default nonoRuntime
-   */
+  /** Sandbox runtime to use */
   runtime: SandboxRuntime;
 }
 

--- a/test/git/worktree.test.ts
+++ b/test/git/worktree.test.ts
@@ -15,7 +15,6 @@ import { tmpdir } from "node:os";
  */
 async function createTestRepo(dir: string): Promise<{
   repoPath: string;
-  barePath: string;
 }> {
   const barePath = join(dir, "bare.git");
   const repoPath = join(dir, "repo");
@@ -35,7 +34,7 @@ async function createTestRepo(dir: string): Promise<{
   await Bun.$`git -C ${repoPath} commit --allow-empty -m "initial commit"`.quiet();
   await Bun.$`git -C ${repoPath} push -u origin main`.quiet();
 
-  return { repoPath, barePath };
+  return { repoPath };
 }
 
 describe("detectRepo", () => {
@@ -50,7 +49,7 @@ describe("detectRepo", () => {
   });
 
   test("finds .git walking up from subdirectory", async () => {
-    const { repoPath, barePath } = await createTestRepo(tmpDir);
+    const { repoPath } = await createTestRepo(tmpDir);
     const subDir = join(repoPath, "src", "deep", "nested");
     await mkdir(subDir, { recursive: true });
 
@@ -58,8 +57,6 @@ describe("detectRepo", () => {
 
     expect(result.repoPath).toBe(repoPath);
     expect(result.defaultBranch).toBe("main");
-    // Remote should contain the bare path
-    expect(result.remote).toContain(barePath);
   });
 
   test("finds .git from repo root directly", async () => {

--- a/test/sandbox/claude-config-guard.test.ts
+++ b/test/sandbox/claude-config-guard.test.ts
@@ -98,22 +98,6 @@ describe("ClaudeConfigGuard", () => {
     guard.stop();
   });
 
-  test("acknowledge() clears alerts", async () => {
-    const home = await makeFakeHome();
-    await writeFile(join(home, ".claude", "settings.json"), '{}');
-    process.env.HOME = home;
-
-    const guard = await startClaudeConfigGuard();
-
-    await writeFile(join(home, ".claude", "settings.json"), '{"modified": true}');
-    await Bun.sleep(600);
-
-    expect(guard.alerts.length).toBeGreaterThanOrEqual(1);
-    guard.acknowledge();
-    expect(guard.alerts).toHaveLength(0);
-    guard.stop();
-  });
-
   test("does not duplicate alerts for the same file", async () => {
     const home = await makeFakeHome();
     await writeFile(join(home, ".claude", "settings.json"), '{}');


### PR DESCRIPTION
## Summary

Review of the codebase identified several pieces of dead code and unused functionality that were removed to simplify the implementation.

## Changes

- **`src/agent.ts`**: Remove prompt file write/cleanup — `.deer-prompt` file was written then immediately deleted after Claude launch, serving no purpose
- **`src/git/finalize.ts`**: Remove cleanup of `.deer-claude-config` and `.deer-prompt` internal files before staging (no longer created)
- **`src/git/worktree.ts`**: Remove `remote` field from `RepoInfo` interface and `detectRepo()` — the remote URL was fetched but never used by callers
- **`src/sandbox/claude-config-guard.ts`**: Remove `acknowledge()` method from `ClaudeConfigGuard` interface — was never called outside tests
- **`src/sandbox/index.ts`**: Remove stale `@default nonoRuntime` JSDoc comment (nono is disabled)
- **`test/git/worktree.test.ts`**: Remove `barePath` from test helper return and assertions for removed `remote` field
- **`test/sandbox/claude-config-guard.test.ts`**: Remove test for deleted `acknowledge()` method

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.