### PR TITLE
🦌 Isolate credentials from bwrap sandbox via API proxy

### DIFF
--- a/src/sandbox/bwrap.ts
+++ b/src/sandbox/bwrap.ts
@@ -1,6 +1,8 @@
 import { join, dirname } from "node:path";
 import { existsSync, lstatSync, readlinkSync, readdirSync, realpathSync } from "node:fs";
-import { startProxy } from "./proxy";
+import { readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { startProxy, startApiProxy, type HostCredentials } from "./proxy";
 import type { SandboxRuntime, SandboxRuntimeOptions, SandboxCleanup } from "./runtime";
 
 /**
@@ -21,12 +23,75 @@ const SYSTEM_PATHS = [
 ];
 
 /**
+ * Read Anthropic credentials from the host environment and config files.
+ * Caller-supplied env vars take precedence over host env and config files.
+ */
+async function readHostCredentials(env?: Record<string, string>): Promise<HostCredentials> {
+  // Caller-supplied env takes highest precedence
+  if (env?.ANTHROPIC_API_KEY) return { apiKey: env.ANTHROPIC_API_KEY };
+  if (env?.CLAUDE_CODE_OAUTH_TOKEN) return { oauthToken: env.CLAUDE_CODE_OAUTH_TOKEN };
+
+  // Host environment
+  if (process.env.ANTHROPIC_API_KEY) return { apiKey: process.env.ANTHROPIC_API_KEY };
+
+  const home = process.env.HOME ?? "/root";
+
+  // OAuth token from ~/.claude/.credentials.json
+  const credentialsFile = join(home, ".claude", ".credentials.json");
+  try {
+    const raw = await readFile(credentialsFile, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const oauth = parsed.claudeAiOauth as Record<string, unknown> | undefined;
+    const token = oauth?.accessToken as string | undefined;
+    if (token) return { oauthToken: token };
+  } catch {
+    // File absent or unreadable
+  }
+
+  // API key from ~/.claude.json
+  const claudeJsonPath = join(home, ".claude.json");
+  try {
+    const raw = await readFile(claudeJsonPath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const key = parsed.primaryApiKey as string | undefined;
+    if (key) return { apiKey: key };
+  } catch {
+    // File absent or unreadable
+  }
+
+  return {};
+}
+
+/**
+ * Write a sanitized copy of ~/.claude.json with credential fields removed.
+ * Returns the path to the temp file.
+ */
+async function createSanitizedClaudeJson(sourcePath: string): Promise<string> {
+  const tmpPath = join(tmpdir(), `deer-claude-sanitized-${Date.now()}.json`);
+  try {
+    const raw = await readFile(sourcePath, "utf-8");
+    const config = JSON.parse(raw) as Record<string, unknown>;
+    delete config.primaryApiKey;
+    delete config.oauthAccount;
+    await writeFile(tmpPath, JSON.stringify(config));
+  } catch {
+    await writeFile(tmpPath, "{}");
+  }
+  return tmpPath;
+}
+
+/** Env vars that carry credentials — intercepted by the API proxy, never passed to the sandbox */
+const CREDENTIAL_ENV_VARS = new Set(["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]);
+
+/**
  * Build the bwrap argument array for a given proxy port and options.
  */
 function buildBwrapArgs(
   options: SandboxRuntimeOptions,
   innerCommand: string[],
   proxyPort: number,
+  apiProxyPort: number,
+  sanitizedClaudeJsonPath: string | null,
 ): string[] {
   const { worktreePath, repoGitDir, extraReadPaths, extraWritePaths, env } = options;
   const home = process.env.HOME ?? "/root";
@@ -80,12 +145,25 @@ function buildBwrapArgs(
   if (existsSync(claudeDir)) {
     homeMounts.add(claudeDir);
     args.push("--bind", claudeDir, claudeDir);
+
+    // Mask credential files within ~/.claude/ — bind an empty temp file over
+    // them so the sandbox sees no tokens. Real credentials are injected by the
+    // API proxy running on the host side.
+    for (const credFile of [".credentials.json", "agent-oauth-token"]) {
+      const fullPath = join(claudeDir, credFile);
+      if (existsSync(fullPath)) {
+        // Use /dev/null — writes are silently discarded, reads return empty
+        args.push("--bind", "/dev/null", fullPath);
+      }
+    }
   }
 
-  // ~/.claude.json — Claude Code writes config and backup files here.
+  // ~/.claude.json — bind a sanitized copy (no primaryApiKey, no oauthAccount)
+  // at the original path. Real credentials are injected by the API proxy.
   const claudeJson = join(home, ".claude.json");
-  if (existsSync(claudeJson)) {
-    args.push("--bind", claudeJson, claudeJson);
+  const claudeJsonSource = sanitizedClaudeJsonPath ?? claudeJson;
+  if (existsSync(claudeJsonSource)) {
+    args.push("--bind", claudeJsonSource, claudeJson);
   }
 
   // Specific ~/.config sub-paths needed by tools (git, gh, deer).
@@ -157,16 +235,26 @@ function buildBwrapArgs(
   args.push("--die-with-parent");
   args.push("--chdir", worktreePath);
 
-  // Environment: proxy settings
+  // Environment: CONNECT proxy settings for network allowlisting
   if (proxyPort > 0) {
     const proxyUrl = `http://127.0.0.1:${proxyPort}`;
     args.push("--setenv", "HTTPS_PROXY", proxyUrl);
     args.push("--setenv", "HTTP_PROXY", proxyUrl);
   }
 
-  // Custom environment variables (e.g. CLAUDE_CODE_OAUTH_TOKEN)
+  // API proxy: redirect all Anthropic API calls to the host-side proxy that injects
+  // real credentials. The sandbox gets a dummy key so Claude Code can start, but it
+  // is not a real credential — the proxy strips it and substitutes the host's real key.
+  if (apiProxyPort > 0) {
+    args.push("--setenv", "ANTHROPIC_BASE_URL", `http://127.0.0.1:${apiProxyPort}`);
+    args.push("--setenv", "ANTHROPIC_API_KEY", "deer-proxy-key");
+  }
+
+  // Custom environment variables — credential vars are intercepted for the API
+  // proxy and must never be forwarded directly into the sandbox.
   if (env) {
     for (const [key, value] of Object.entries(env)) {
+      if (CREDENTIAL_ENV_VARS.has(key)) continue;
       args.push("--setenv", key, value);
     }
   }
@@ -211,21 +299,43 @@ function buildBwrapArgs(
  */
 export function createBwrapRuntime(): SandboxRuntime {
   let proxyPort = 0;
+  let apiProxyPort = 0;
+  let sanitizedClaudeJsonPath: string | null = null;
 
   return {
     name: "bwrap",
 
     async prepare(options: SandboxRuntimeOptions): Promise<SandboxCleanup> {
-      const proxy = await startProxy({ allowlist: options.allowlist });
+      const credentials = await readHostCredentials(options.env);
+
+      const [proxy, apiProxy] = await Promise.all([
+        startProxy({ allowlist: options.allowlist }),
+        startApiProxy({ credentials }),
+      ]);
       proxyPort = proxy.port;
-      return () => {
+      apiProxyPort = apiProxy.port;
+
+      // Create a sanitized ~/.claude.json without credential fields
+      const home = process.env.HOME ?? "/root";
+      const claudeJsonPath = join(home, ".claude.json");
+      if (existsSync(claudeJsonPath)) {
+        sanitizedClaudeJsonPath = await createSanitizedClaudeJson(claudeJsonPath);
+      }
+
+      return async () => {
         proxy.stop();
+        apiProxy.stop();
         proxyPort = 0;
+        apiProxyPort = 0;
+        if (sanitizedClaudeJsonPath) {
+          await rm(sanitizedClaudeJsonPath, { force: true }).catch(() => {});
+          sanitizedClaudeJsonPath = null;
+        }
       };
     },
 
     buildCommand(options: SandboxRuntimeOptions, innerCommand: string[]): string[] {
-      return buildBwrapArgs(options, innerCommand, proxyPort);
+      return buildBwrapArgs(options, innerCommand, proxyPort, apiProxyPort, sanitizedClaudeJsonPath);
     },
   };
 }

--- a/src/sandbox/proxy.ts
+++ b/src/sandbox/proxy.ts
@@ -57,6 +57,174 @@ export function isPrivateIP(ip: string): boolean {
   return false;
 }
 
+// ── Direct HTTP request (proxy-bypassing) ─────────────────────────────
+
+/**
+ * Make a direct HTTP or HTTPS request via Bun.connect, bypassing any
+ * HTTP_PROXY/HTTPS_PROXY environment variables that Bun's fetch() and
+ * node:http both respect unconditionally.
+ */
+async function directRequest(
+  url: string,
+  method: string,
+  headers: Headers,
+  body?: Buffer,
+): Promise<Response> {
+  const parsed = new URL(url);
+  const isHttps = parsed.protocol === "https:";
+  const port = parseInt(parsed.port) || (isHttps ? 443 : 80);
+
+  // Build HTTP/1.1 request bytes
+  const headerLines: string[] = [
+    `${method} ${parsed.pathname}${parsed.search} HTTP/1.1`,
+    `Host: ${parsed.host}`,
+  ];
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() !== "host") headerLines.push(`${key}: ${value}`);
+  });
+  if (body) headerLines.push(`Content-Length: ${body.length}`);
+  headerLines.push("Connection: close", "", "");
+
+  const requestBytes = Buffer.concat([
+    Buffer.from(headerLines.join("\r\n")),
+    body ?? Buffer.alloc(0),
+  ]);
+
+  return new Promise<Response>((resolve, reject) => {
+    let accumulated = Buffer.alloc(0);
+    let resolved = false;
+
+    function tryParse(end: boolean): void {
+      const str = accumulated.toString("latin1");
+      const headerEnd = str.indexOf("\r\n\r\n");
+      if (headerEnd < 0) {
+        if (end) reject(new Error("Connection closed before full HTTP response"));
+        return;
+      }
+
+      const headerSection = str.slice(0, headerEnd);
+      const lines = headerSection.split("\r\n");
+      const status = parseInt(lines[0]?.split(" ")[1] ?? "0");
+
+      const resHeaders = new Headers();
+      for (const line of lines.slice(1)) {
+        const colonIdx = line.indexOf(":");
+        if (colonIdx > 0) {
+          resHeaders.set(line.slice(0, colonIdx).trim(), line.slice(colonIdx + 1).trim());
+        }
+      }
+
+      const bodyBuf = accumulated.slice(headerEnd + 4);
+      const contentLength = parseInt(resHeaders.get("content-length") ?? "-1");
+      if (!end && contentLength >= 0 && bodyBuf.length < contentLength) return;
+
+      resolved = true;
+      resolve(new Response(bodyBuf, { status, headers: resHeaders }));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const connectOpts: any = {
+      hostname: parsed.hostname,
+      port,
+      socket: {
+        open(socket: { write: (b: Buffer) => void }) {
+          socket.write(requestBytes);
+        },
+        data(_socket: unknown, data: Uint8Array) {
+          accumulated = Buffer.concat([accumulated, Buffer.from(data)]);
+          if (!resolved) tryParse(false);
+        },
+        close() {
+          if (!resolved) tryParse(true);
+        },
+        error(_socket: unknown, err: Error) {
+          if (!resolved) reject(err);
+        },
+      },
+    };
+    if (isHttps) connectOpts.tls = {};
+
+    Bun.connect(connectOpts);
+  });
+}
+
+// ── API proxy ─────────────────────────────────────────────────────────
+
+export interface HostCredentials {
+  /** Anthropic API key for the x-api-key header */
+  apiKey?: string;
+  /** OAuth access token for the Authorization: Bearer header */
+  oauthToken?: string;
+}
+
+export interface ApiProxyOptions {
+  /** Credentials to inject into forwarded Anthropic API requests */
+  credentials: HostCredentials;
+  /**
+   * Base URL of the upstream Anthropic API.
+   * @default "https://api.anthropic.com"
+   */
+  upstreamBaseUrl?: string;
+}
+
+/**
+ * Start an HTTP API proxy that injects host credentials into Anthropic API requests.
+ *
+ * Sandboxed Claude instances point ANTHROPIC_BASE_URL at this proxy. The proxy
+ * strips any auth headers sent by the sandbox and replaces them with real
+ * credentials read from the host. This ensures credentials never exist inside
+ * the sandbox — only the proxy (running on the host) holds them.
+ *
+ * Returns a handle with the listening port and a stop function.
+ */
+export async function startApiProxy(options: ApiProxyOptions): Promise<ProxyHandle> {
+  const { credentials, upstreamBaseUrl = "https://api.anthropic.com" } = options;
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      const url = new URL(req.url);
+      const upstreamUrl = `${upstreamBaseUrl}${url.pathname}${url.search}`;
+
+      const headers = new Headers(req.headers);
+      // Strip any auth the sandbox sends (it only has a dummy key)
+      headers.delete("x-api-key");
+      headers.delete("authorization");
+      // Remove host so the upstream sets it correctly
+      headers.delete("host");
+
+      // Inject real host credentials
+      if (credentials.apiKey) {
+        headers.set("x-api-key", credentials.apiKey);
+      } else if (credentials.oauthToken) {
+        headers.set("authorization", `Bearer ${credentials.oauthToken}`);
+      }
+
+      const reqBody =
+        req.method !== "GET" && req.method !== "HEAD"
+          ? Buffer.from(await req.arrayBuffer())
+          : undefined;
+
+      // Forward directly to the upstream API using Bun.connect (raw TCP).
+      // This bypasses HTTP_PROXY/HTTPS_PROXY env vars, which Bun's fetch()
+      // and node:http always respect, even with agent:false.
+      const response = await directRequest(upstreamUrl, req.method, headers, reqBody);
+
+      return response;
+    },
+  });
+
+  return {
+    port: server.port,
+    stop() {
+      server.stop(true);
+    },
+  };
+}
+
+// ── CONNECT proxy ─────────────────────────────────────────────────────
+
 /** Per-connection upstream socket tracking */
 const upstreams = new WeakMap<object, NetSocket>();
 

--- a/test/sandbox/bwrap.test.ts
+++ b/test/sandbox/bwrap.test.ts
@@ -1,7 +1,7 @@
-import { test, expect, describe, afterEach } from "bun:test";
+import { test, expect, describe, afterEach, beforeEach } from "bun:test";
 import { createBwrapRuntime } from "../../src/sandbox/bwrap";
 import type { SandboxRuntimeOptions, SandboxCleanup } from "../../src/sandbox/runtime";
-import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -88,6 +88,141 @@ describe("bwrapRuntime.buildCommand", () => {
     const sepIdx = args.indexOf("--");
     expect(sepIdx).toBeGreaterThan(0);
     expect(args.slice(sepIdx + 1)).toEqual(["claude", "--model", "sonnet"]);
+  });
+});
+
+describe("bwrap credential isolation", () => {
+  const tmpDirs: string[] = [];
+  const cleanups: SandboxCleanup[] = [];
+
+  afterEach(async () => {
+    for (const c of cleanups) c();
+    cleanups.length = 0;
+    for (const d of tmpDirs) {
+      await rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+    tmpDirs.length = 0;
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "deer-bwrap-cred-test-"));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  test("ANTHROPIC_BASE_URL points at API proxy after prepare()", async () => {
+    const dir = await makeTmpDir();
+    const runtime = createBwrapRuntime();
+    const cleanup = await runtime.prepare!({ worktreePath: dir, allowlist: [] });
+    cleanups.push(cleanup);
+
+    const args = runtime.buildCommand({ worktreePath: dir, allowlist: [] }, ["echo"]);
+    const baseUrlIdx = args.indexOf("ANTHROPIC_BASE_URL");
+    expect(baseUrlIdx).toBeGreaterThan(0);
+    expect(args[baseUrlIdx - 1]).toBe("--setenv");
+    expect(args[baseUrlIdx + 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+  });
+
+  test("dummy ANTHROPIC_API_KEY is set (not a real sk-ant- key)", async () => {
+    const dir = await makeTmpDir();
+    const runtime = createBwrapRuntime();
+    const cleanup = await runtime.prepare!({ worktreePath: dir, allowlist: [] });
+    cleanups.push(cleanup);
+
+    const args = runtime.buildCommand({ worktreePath: dir, allowlist: [] }, ["echo"]);
+    const keyIdx = args.indexOf("ANTHROPIC_API_KEY");
+    expect(keyIdx).toBeGreaterThan(0);
+    expect(args[keyIdx - 1]).toBe("--setenv");
+    // Must not be a real Anthropic API key format
+    expect(args[keyIdx + 1]).not.toMatch(/^sk-ant-/);
+  });
+
+  test("real ANTHROPIC_API_KEY from host env is not passed through to sandbox args", async () => {
+    const originalKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "sk-ant-host-secret-key";
+
+    const dir = await makeTmpDir();
+    const runtime = createBwrapRuntime();
+    const cleanup = await runtime.prepare!({ worktreePath: dir, allowlist: [] });
+    cleanups.push(cleanup);
+
+    const args = runtime.buildCommand({ worktreePath: dir, allowlist: [] }, ["echo"]);
+    expect(args).not.toContain("sk-ant-host-secret-key");
+
+    process.env.ANTHROPIC_API_KEY = originalKey;
+  });
+
+  test(".credentials.json is masked inside the sandbox", async () => {
+    const fakeHome = await makeTmpDir();
+    const claudeDir = join(fakeHome, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+    const credFile = join(claudeDir, ".credentials.json");
+    await writeFile(credFile, JSON.stringify({ claudeAiOauth: { accessToken: "secret-oauth-token" } }));
+
+    const dir = await makeTmpDir();
+    const runtime = createBwrapRuntime();
+
+    // Temporarily override HOME so bwrap picks up our fake home
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    const cleanup = await runtime.prepare!({ worktreePath: dir, allowlist: [] });
+    cleanups.push(cleanup);
+    const args = runtime.buildCommand({ worktreePath: dir, allowlist: [] }, ["echo"]);
+
+    process.env.HOME = originalHome;
+
+    // .credentials.json should be bound to an empty/masked source, not the real one
+    const credIdx = args.findIndex((a) => a === credFile);
+    expect(credIdx).toBeGreaterThan(0);
+    const sourceArg = args[credIdx - 1];
+    // The source must NOT be the real credentials file itself
+    expect(sourceArg).not.toBe(credFile);
+  });
+
+  test("primaryApiKey is absent from the mounted ~/.claude.json", async () => {
+    const fakeHome = await makeTmpDir();
+    const claudeJsonPath = join(fakeHome, ".claude.json");
+    await writeFile(claudeJsonPath, JSON.stringify({
+      primaryApiKey: "sk-ant-stored-key",
+      numStartups: 5,
+    }));
+
+    const dir = await makeTmpDir();
+    const runtime = createBwrapRuntime();
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    const cleanup = await runtime.prepare!({ worktreePath: dir, allowlist: [] });
+    cleanups.push(cleanup);
+    const args = runtime.buildCommand({ worktreePath: dir, allowlist: [] }, ["echo"]);
+
+    process.env.HOME = originalHome;
+
+    // Find what source file is bound at the ~/.claude.json target
+    const targetIdx = args.findIndex((a) => a === claudeJsonPath);
+    expect(targetIdx).toBeGreaterThan(0);
+    const sourceArg = args[targetIdx - 1];
+
+    // The source is a sanitized temp file — its content must not contain the real API key
+    const content = await readFile(sourceArg, "utf-8");
+    expect(content).not.toContain("sk-ant-stored-key");
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    expect(parsed.numStartups).toBe(5); // other config preserved
+  });
+
+  test("CLAUDE_CODE_OAUTH_TOKEN in env is not forwarded to sandbox", async () => {
+    const dir = await makeTmpDir();
+    const runtime = createBwrapRuntime();
+    const cleanup = await runtime.prepare!({ worktreePath: dir, allowlist: [] });
+    cleanups.push(cleanup);
+
+    const args = runtime.buildCommand(
+      { worktreePath: dir, allowlist: [], env: { CLAUDE_CODE_OAUTH_TOKEN: "my-oauth-token" } },
+      ["echo"],
+    );
+    expect(args).not.toContain("my-oauth-token");
   });
 });
 

--- a/test/sandbox/proxy.test.ts
+++ b/test/sandbox/proxy.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, afterEach } from "bun:test";
-import { startProxy, matchesAllowlist, isPrivateIP, type ProxyHandle } from "../../src/sandbox/proxy";
+import { startProxy, startApiProxy, matchesAllowlist, isPrivateIP, type ProxyHandle } from "../../src/sandbox/proxy";
 import { createServer, type Server } from "node:net";
 
 describe("matchesAllowlist", () => {
@@ -254,6 +254,193 @@ describe("proxy server", () => {
     h.stop();
     handles.length = 0;
 
+    try {
+      await fetch(`http://127.0.0.1:${port}/`);
+      expect(true).toBe(false);
+    } catch {
+      // Expected — server is stopped
+    }
+  });
+});
+
+describe("startApiProxy", () => {
+  const apiHandles: ProxyHandle[] = [];
+  const upstreamServers: Server[] = [];
+
+  afterEach(async () => {
+    for (const h of apiHandles) h.stop();
+    apiHandles.length = 0;
+    for (const s of upstreamServers) s.close();
+    upstreamServers.length = 0;
+  });
+
+  /**
+   * Send an HTTP/1.1 request directly via TCP (bypasses HTTP_PROXY env var).
+   * Returns status code and response body.
+   */
+  function sendHttpRequest(
+    port: number,
+    method: string,
+    path: string,
+    body?: string,
+    extraHeaders?: Record<string, string>,
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      let resolved = false;
+      const bodyBytes = body ? Buffer.from(body) : Buffer.alloc(0);
+      const headerLines = [
+        `${method} ${path} HTTP/1.1`,
+        `Host: 127.0.0.1:${port}`,
+        `Content-Length: ${bodyBytes.length}`,
+        "Connection: close",
+        ...Object.entries(extraHeaders ?? {}).map(([k, v]) => `${k}: ${v}`),
+        "",
+        "",
+      ].join("\r\n");
+
+      const req = headerLines + (body ?? "");
+
+      Bun.connect({
+        hostname: "127.0.0.1",
+        port,
+        socket: {
+          open(socket) {
+            socket.write(req);
+          },
+          data(socket, data) {
+            const text = Buffer.from(data).toString();
+            const sepIdx = text.indexOf("\r\n\r\n");
+            const headerSection = sepIdx >= 0 ? text.slice(0, sepIdx) : text;
+            const firstLine = headerSection.split("\r\n")[0];
+            const status = parseInt(firstLine.split(" ")[1] ?? "0");
+            const respBody = sepIdx >= 0 ? text.slice(sepIdx + 4) : "";
+            resolved = true;
+            resolve({ status, body: respBody });
+            socket.end();
+          },
+          close() {
+            if (!resolved) reject(new Error("closed before response"));
+          },
+          error(_, e) {
+            if (!resolved) reject(e);
+          },
+        },
+      });
+    });
+  }
+
+  /**
+   * Start a plain TCP server that records the raw request and returns a canned HTTP response.
+   * Used to inspect what headers the API proxy forwards upstream.
+   */
+  function startRecordingUpstream(
+    responseBody: string = "{}",
+    status: number = 200,
+  ): Promise<{ port: number; lastRequest: () => string }> {
+    let lastRequest = "";
+
+    const server = createServer((socket) => {
+      socket.on("data", (data) => {
+        lastRequest += data.toString();
+        // Once we have the full headers, send response
+        if (lastRequest.includes("\r\n\r\n")) {
+          socket.write(
+            `HTTP/1.1 ${status} OK\r\nContent-Type: application/json\r\nContent-Length: ${responseBody.length}\r\nConnection: close\r\n\r\n${responseBody}`,
+          );
+          socket.end();
+        }
+      });
+    });
+    upstreamServers.push(server);
+    return new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        resolve({ port, lastRequest: () => lastRequest });
+      });
+    });
+  }
+
+  test("starts and returns a positive port", async () => {
+    const h = await startApiProxy({
+      credentials: { apiKey: "sk-ant-test" },
+    });
+    apiHandles.push(h);
+    expect(h.port).toBeGreaterThan(0);
+  });
+
+  test("injects x-api-key when apiKey credential provided", async () => {
+    const upstream = await startRecordingUpstream();
+    const h = await startApiProxy({
+      credentials: { apiKey: "sk-ant-real-key" },
+      upstreamBaseUrl: `http://127.0.0.1:${upstream.port}`,
+    });
+    apiHandles.push(h);
+
+    await sendHttpRequest(h.port, "POST", "/v1/messages", "{}");
+    expect(upstream.lastRequest()).toContain("x-api-key: sk-ant-real-key");
+  });
+
+  test("injects Authorization Bearer when oauthToken credential provided", async () => {
+    const upstream = await startRecordingUpstream();
+    const h = await startApiProxy({
+      credentials: { oauthToken: "oauth-token-xyz" },
+      upstreamBaseUrl: `http://127.0.0.1:${upstream.port}`,
+    });
+    apiHandles.push(h);
+
+    await sendHttpRequest(h.port, "POST", "/v1/messages", "{}");
+    expect(upstream.lastRequest()).toContain("authorization: Bearer oauth-token-xyz");
+  });
+
+  test("strips dummy x-api-key sent by sandbox and injects real key", async () => {
+    const upstream = await startRecordingUpstream();
+    const h = await startApiProxy({
+      credentials: { apiKey: "sk-ant-real-key" },
+      upstreamBaseUrl: `http://127.0.0.1:${upstream.port}`,
+    });
+    apiHandles.push(h);
+
+    // Sandbox sends its dummy key — proxy must replace with the real one
+    await sendHttpRequest(h.port, "POST", "/v1/messages", "{}", { "x-api-key": "deer-proxy-key" });
+    expect(upstream.lastRequest()).toContain("x-api-key: sk-ant-real-key");
+    expect(upstream.lastRequest()).not.toContain("deer-proxy-key");
+  });
+
+  test("forwards request body to upstream", async () => {
+    const upstream = await startRecordingUpstream();
+    const h = await startApiProxy({
+      credentials: { apiKey: "sk-ant-test" },
+      upstreamBaseUrl: `http://127.0.0.1:${upstream.port}`,
+    });
+    apiHandles.push(h);
+
+    await sendHttpRequest(h.port, "POST", "/v1/messages", '{"model":"claude-sonnet-4-6"}', {
+      "content-type": "application/json",
+    });
+    expect(upstream.lastRequest()).toContain('{"model":"claude-sonnet-4-6"}');
+  });
+
+  test("returns upstream response status and body", async () => {
+    const upstream = await startRecordingUpstream('{"error":"not_found"}', 404);
+    const h = await startApiProxy({
+      credentials: { apiKey: "sk-ant-test" },
+      upstreamBaseUrl: `http://127.0.0.1:${upstream.port}`,
+    });
+    apiHandles.push(h);
+
+    const res = await sendHttpRequest(h.port, "POST", "/v1/messages", "{}");
+    expect(res.status).toBe(404);
+    expect(res.body).toContain('{"error":"not_found"}');
+  });
+
+  test("stop() shuts down the API proxy", async () => {
+    const h = await startApiProxy({ credentials: { apiKey: "sk-ant-test" } });
+    const port = h.port;
+    h.stop();
+
+    // fetch() goes through HTTP_PROXY which in turn tries to CONNECT to our stopped
+    // server — the connection is refused, so fetch throws.
     try {
       await fetch(`http://127.0.0.1:${port}/`);
       expect(true).toBe(false);


### PR DESCRIPTION
## Summary

Bwrap-sandboxed Claude instances previously had access to host credentials (API keys, OAuth tokens) through environment variables and bind-mounted config files. This change ensures credentials never exist inside the sandbox — instead, a host-side API proxy intercepts Anthropic API requests and injects the real credentials transparently.

## Changes

- Add `startApiProxy()` to `src/sandbox/proxy.ts`: an HTTP proxy that strips any auth headers from sandboxed requests and injects real host credentials before forwarding to `api.anthropic.com`
- Add `directRequest()` helper that bypasses `HTTP_PROXY`/`HTTPS_PROXY` env vars when forwarding to upstream (prevents proxy-of-proxy loops)
- Add `readHostCredentials()` to `src/sandbox/bwrap.ts`: reads credentials from env, `~/.claude/.credentials.json`, or `~/.claude.json` in priority order
- Add `createSanitizedClaudeJson()`: writes a temp copy of `~/.claude.json` with `primaryApiKey` and `oauthAccount` fields removed before bind-mounting it into the sandbox
- Mask `~/.claude/.credentials.json` and `~/.claude/agent-oauth-token` inside the sandbox by binding `/dev/null` over them
- Set `ANTHROPIC_BASE_URL` in the sandbox to point at the API proxy; set a dummy `ANTHROPIC_API_KEY` so Claude Code can start, but it carries no real auth
- Block `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` from being forwarded via `--setenv` into the sandbox
- Start and stop the API proxy alongside the CONNECT proxy in `prepare()`/cleanup
- Add comprehensive tests for all credential isolation guarantees

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.