### PR TITLE
🦌 Add build process and bunx/install support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@types/react": "^19.0.0",
         "bun-types": "latest",
+        "react-devtools-core": "^7.0.1",
         "typescript": "^5.9.3",
       },
     },
@@ -86,11 +87,15 @@
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -116,9 +121,11 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "ink/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
-  "name": "deer",
+  "name": "@zdavison/deer",
   "version": "0.1.0",
   "description": "Unattended coding agent.",
   "type": "module",
   "bin": {
     "deer": "src/cli.tsx"
   },
+  "files": [
+    "src/"
+  ],
   "scripts": {
     "test": "bun test",
-    "dev": "bun run src/cli.tsx"
+    "dev": "bun run src/cli.tsx",
+    "build": "mkdir -p dist && bun build --compile src/cli.tsx --outfile dist/deer"
   },
   "dependencies": {
     "@iarna/toml": "^3.0.0",
@@ -19,6 +23,7 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "bun-types": "latest",
+    "react-devtools-core": "^7.0.1",
     "typescript": "^5.9.3"
   }
 }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -4,6 +4,12 @@
 // Deer must use CLAUDE_CODE_OAUTH_TOKEN for all Claude API access.
 delete process.env.ANTHROPIC_API_KEY;
 
+if (process.argv[2] === "install") {
+  const { installDeer } = await import("./install.ts");
+  await installDeer();
+  process.exit(0);
+}
+
 import { render } from "ink";
 import React from "react";
 import { detectRepo } from "./git/worktree.ts";

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,37 @@
+import { join } from "node:path";
+import { accessSync, constants } from "node:fs";
+
+const INSTALL_PATH = "/usr/local/bin/deer";
+
+export async function installDeer(): Promise<void> {
+  // import.meta.dir is src/, go up one level to the package root
+  const packageRoot = join(import.meta.dir, "..");
+  const entrypoint = join(packageRoot, "src", "cli.tsx");
+
+  // Verify the source entrypoint exists (sanity check)
+  try {
+    accessSync(entrypoint, constants.R_OK);
+  } catch {
+    console.error(`Error: source file not found at ${entrypoint}`);
+    process.exit(1);
+  }
+
+  console.log("Compiling deer (this may take a moment)...");
+
+  const result = Bun.spawnSync(
+    ["bun", "build", "--compile", entrypoint, "--outfile", INSTALL_PATH],
+    { stdio: ["inherit", "inherit", "inherit"] },
+  );
+
+  if (result.exitCode !== 0) {
+    if (result.exitCode === 1) {
+      console.error(
+        `\nInstall failed. If this is a permission error, try:\n  sudo bunx @zdavison/deer install`,
+      );
+    }
+    process.exit(result.exitCode ?? 1);
+  }
+
+  console.log(`\nInstalled deer to ${INSTALL_PATH}`);
+  console.log("Run 'deer' to launch.");
+}


### PR DESCRIPTION
## Summary

Sets up a build and distribution process so deer can be run via `bunx @zdavison/deer`. Adds an `install` subcommand that compiles a standalone binary to `/usr/local/bin/deer` so users can run `deer` without requiring bun to be installed.

## Changes

- Renamed package to `@zdavison/deer` and added `files` field to include `src/` in the published package
- Added `build` script: `bun build --compile src/cli.tsx --outfile dist/deer`
- Added `src/install.ts` — compiles a standalone binary to `/usr/local/bin/deer` via `bun build --compile`
- Wired `bunx @zdavison/deer install` in `src/cli.tsx` to invoke the install flow before the main TUI starts
- Added `react-devtools-core` dev dependency (required for compile target)

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.