### PR TITLE
🦌 Fix status icons shifting with long agent titles

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1012,16 +1012,18 @@ export default function Dashboard({ cwd }: { cwd: string }) {
               <Box key={agent.id} flexDirection="column">
                 {/* Title line */}
                 <Box gap={1}>
+                  <Box width={2}>
+                    {agent.creatingPr ? (
+                      <Text color="blue">{UPLOAD_FRAMES[animTick % UPLOAD_FRAMES.length]}</Text>
+                    ) : agent.idle ? (
+                      <Text>{agent.result?.prUrl ? "👀" : "👋"}</Text>
+                    ) : agent.status === "running" ? (
+                      <Spinner label="" />
+                    ) : (
+                      <Text color={display.color}>{display.icon}</Text>
+                    )}
+                  </Box>
                   <Text dimColor={!isSelected}>{pointer}</Text>
-                  {agent.creatingPr ? (
-                    <Text color="blue">{UPLOAD_FRAMES[animTick % UPLOAD_FRAMES.length]}</Text>
-                  ) : agent.idle ? (
-                    <Text>{agent.result?.prUrl ? "👀" : "👋"}</Text>
-                  ) : agent.status === "running" ? (
-                    <Spinner label="" />
-                  ) : (
-                    <Text color={display.color}>{display.icon}</Text>
-                  )}
                   <Box flexGrow={1}>
                     <Text bold={isSelected} wrap="truncate">
                       {truncate(agent.prompt, titleWidth)}


### PR DESCRIPTION
## Summary

Status icons (spinner, emoji, upload indicator) were inline with the title text, causing them to shift horizontally when titles were long or truncated differently. This moves all status indicators into a fixed-width column on the far left so they are always vertically aligned regardless of title length.

## Changes

- Wrap status icon rendering in a `<Box width={2}>` fixed-width container
- Move the status icon box before the selection pointer, ensuring consistent left-edge alignment across all agent rows

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.