### PR TITLE
🦌 Fix deleted tasks reappearing with '!' on next sync

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -389,6 +389,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   const nextId = useRef(1);
   const agentsRef = useRef(agents);
   agentsRef.current = agents;
+  const deletedTaskIdsRef = useRef(new Set<string>());
   const configRef = useRef<DeerConfig | null>(null);
   const baseBranchRef = useRef("main");
 
@@ -403,7 +404,8 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   // ── Sync state from history file ──────────────────────────────────
 
   const syncWithHistory = useCallback(async () => {
-    const fileTasks = await loadHistory(cwd);
+    const allFileTasks = await loadHistory(cwd);
+    const fileTasks = allFileTasks.filter(t => !deletedTaskIdsRef.current.has(t.taskId));
     const currentAgents = agentsRef.current;
     const agentByTaskId = new Map(currentAgents.map(a => [a.taskId, a]));
     const fileTaskIds = new Set(fileTasks.map(t => t.taskId));
@@ -908,7 +910,10 @@ export default function Dashboard({ cwd }: { cwd: string }) {
             deleteTask(agent.taskId, cwd, agent.handle).catch(() => {});
             setAgents((prev) => prev.filter((a) => a !== agent));
             setSelectedIdx((prev) => Math.min(prev, Math.max(visible.length - 2, 0)));
-            removeFromHistory(cwd, agent.taskId);
+            deletedTaskIdsRef.current.add(agent.taskId);
+            removeFromHistory(cwd, agent.taskId).finally(() => {
+              deletedTaskIdsRef.current.delete(agent.taskId);
+            });
             break;
           case "toggle_logs":
             setLogExpanded((prev) => !prev);


### PR DESCRIPTION
## Summary

When a task was deleted, it would immediately reappear in the list with an error indicator (`!`) before the async `removeFromHistory` call completed. The next `syncWithHistory` tick would reload the task from the history file before the deletion had been written, causing it to resurface.

## Changes

- Added `deletedTaskIdsRef` (a `Set<string>`) to track task IDs that are pending deletion
- Filter out pending-deleted task IDs in `syncWithHistory` so they don't reappear during the async gap
- Track the deleted ID from the moment delete is initiated, and remove it from the set only after `removeFromHistory` resolves

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.