### PR TITLE
🦌 Open worktree shell in tmux session for detach support

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -767,11 +767,18 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     if (!agent.taskId) return;
     const worktreePath = `${dataDir()}/tasks/${agent.taskId}/worktree`;
     const shell = process.env.SHELL ?? "/bin/sh";
+    const sessionName = `deer-shell-${agent.taskId}`;
 
     await withSuspendedTerminal(setSuspended, async () => {
       await Bun.sleep(50);
       const { spawnSync } = await import("node:child_process");
-      spawnSync(shell, [], { stdio: "inherit", cwd: worktreePath });
+      // Create a tmux session (or reattach if it already exists) so that
+      // ctrl+b d detaches and returns to deer, just like attaching to the agent.
+      spawnSync(
+        "tmux",
+        ["new-session", "-A", "-s", sessionName, "-c", worktreePath, shell],
+        { stdio: "inherit" },
+      );
     });
   }, []);
 


### PR DESCRIPTION
## Summary

When pressing `s` to open a shell in a task's worktree, the shell now runs inside a named tmux session instead of a plain subprocess. This means `ctrl+b d` detaches and returns to the deer dashboard, consistent with the behavior when attaching to the agent's Claude session.

## Changes

- Replace `spawnSync(shell, [])` with `spawnSync('tmux', ['new-session', '-A', '-s', sessionName, ...])` so the shell is attached via tmux
- Session is named `deer-shell-<taskId>` and reuses an existing session if one already exists (`-A` flag)
- Working directory is passed to tmux via `-c` instead of the `cwd` spawn option

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.