### PR TITLE
🦌 Fix ghost tasks reappearing after deletion

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -45,6 +45,8 @@ export interface AgentState {
   updatingPr: boolean;
   /** AbortController for cancelling the wait loop */
   abortController: AbortController | null;
+  /** True if this task has been explicitly deleted (suppresses history write on cleanup) */
+  deleted: boolean;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -70,6 +72,7 @@ export function createAgentState(overrides: Partial<AgentState>): AgentState {
     creatingPr: false,
     updatingPr: false,
     abortController: null,
+    deleted: false,
     ...overrides,
   };
 }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -712,7 +712,9 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     } finally {
       if (agent.timer) clearInterval(agent.timer);
       agent.timer = null;
-      await saveToHistory(agent, cwd);
+      if (!agent.deleted) {
+        await saveToHistory(agent, cwd);
+      }
       setAgents((prev) => [...prev]);
     }
   }, [cwd, preflight]);
@@ -981,6 +983,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
             killAgent(agent);
             break;
           case "delete":
+            agent.deleted = true;
             agent.abortController?.abort();
             if (agent.timer) clearInterval(agent.timer);
             deleteTask(agent.taskId, cwd, agent.handle).catch(() => {});


### PR DESCRIPTION
## Summary

Deleted tasks were reappearing in the list with a `!` error indicator shortly after deletion. This happened because the cleanup path in `waitForCompletion` always called `saveToHistory`, which would write a new history entry for the task even after it had been deleted — causing it to be reloaded on the next history scan.

The fix introduces a `deleted` flag on `AgentState`. When a task is explicitly deleted, this flag is set before aborting the agent, and the cleanup path skips writing to history when the flag is set.

## Changes

- Added `deleted: boolean` field to `AgentState` interface (defaults to `false`)
- Set `agent.deleted = true` in the `"delete"` case before aborting the agent
- Guard `saveToHistory` in the cleanup `finally` block with `if (!agent.deleted)`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.