### PR TITLE
🦌 Add retry command for all terminal task states

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -994,9 +994,20 @@ export default function Dashboard({ cwd }: { cwd: string }) {
           case "toggle_logs":
             setLogExpanded((prev) => !prev);
             break;
-          case "retry":
-            spawnAgent(agent.prompt);
+          case "retry": {
+            const retryPrompt = agent.prompt;
+            agent.abortController?.abort();
+            if (agent.timer) clearInterval(agent.timer);
+            deleteTask(agent.taskId, cwd, agent.handle).catch(() => {});
+            setAgents((prev) => prev.filter((a) => a !== agent));
+            setSelectedIdx((prev) => Math.min(prev, Math.max(visible.length - 2, 0)));
+            deletedTaskIdsRef.current.add(agent.taskId);
+            removeFromHistory(cwd, agent.taskId).finally(() => {
+              deletedTaskIdsRef.current.delete(agent.taskId);
+            });
+            spawnAgent(retryPrompt);
             break;
+          }
           case "open_shell":
             openShell(agent);
             break;

--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -74,10 +74,10 @@ const ACTIONS_BY_STATE: Record<AgentState, AgentAction[]> = {
   setup:       ["kill", "delete", "toggle_logs"],
   running:     ["attach", "kill", "open_shell", "delete", "toggle_logs"],
   teardown:    ["open_shell", "delete", "toggle_logs"],
-  completed:   ["attach", "create_pr", "open_pr", "update_pr", "open_shell", "delete", "toggle_logs"],
+  completed:   ["attach", "create_pr", "open_pr", "update_pr", "retry", "open_shell", "delete", "toggle_logs"],
   failed:      ["retry", "open_shell", "delete", "toggle_logs"],
-  cancelled:   ["open_shell", "delete", "toggle_logs"],
-  interrupted: ["open_shell", "delete", "toggle_logs"],
+  cancelled:   ["retry", "open_shell", "delete", "toggle_logs"],
+  interrupted: ["retry", "open_shell", "delete", "toggle_logs"],
 };
 
 // ── Action Bindings ──────────────────────────────────────────────────

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -176,24 +176,33 @@ describe("availableActions", () => {
     expect(actions).toContain("toggle_logs");
   });
 
-  test("retry is not available in non-failed states", () => {
-    for (const status of ["setup", "running", "teardown", "completed", "cancelled", "interrupted"] as const) {
+  test("retry is not available in active states", () => {
+    for (const status of ["setup", "running", "teardown"] as const) {
       const actions = availableActions(baseCtx({ status }));
       expect(actions).not.toContain("retry");
     }
   });
 
-  test("cancelled state has delete, toggle_logs", () => {
+  test("retry is available in all terminal states", () => {
+    for (const status of ["failed", "completed", "cancelled", "interrupted"] as const) {
+      const actions = availableActions(baseCtx({ status }));
+      expect(actions).toContain("retry");
+    }
+  });
+
+  test("cancelled state has retry, delete, toggle_logs", () => {
     const actions = availableActions(baseCtx({
       status: "cancelled",
       hasHandle: true,
     }));
+    expect(actions).toContain("retry");
     expect(actions).toContain("delete");
     expect(actions).toContain("toggle_logs");
   });
 
-  test("interrupted state has delete, toggle_logs", () => {
+  test("interrupted state has retry, delete, toggle_logs", () => {
     const actions = availableActions(baseCtx({ status: "interrupted" }));
+    expect(actions).toContain("retry");
     expect(actions).toContain("delete");
     expect(actions).toContain("toggle_logs");
     expect(actions).not.toContain("attach");


### PR DESCRIPTION
## Summary

Adds a working `r` retry command that re-creates a task with the same prompt, deleting the old one. Previously, retry existed as a binding but only spawned a new agent without cleaning up the original. Now retry properly aborts the agent, clears its timer, deletes the task from history, removes it from the agent list, and spawns a fresh agent with the same prompt.

Retry is also now available in `completed`, `cancelled`, and `interrupted` states — not just `failed`.

## Changes

- **`src/dashboard.tsx`**: Retry case now aborts the agent, clears its interval, deletes the task, removes it from state, and spawns a new agent with the original prompt
- **`src/state-machine.ts`**: Added `retry` to `completed`, `cancelled`, and `interrupted` action lists
- **`test/state-machine.test.ts`**: Updated tests to reflect retry availability in all terminal states (`failed`, `completed`, `cancelled`, `interrupted`)

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.