### PR TITLE
🦌 Pause TUI elapsed timer while agent is idle

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -579,9 +579,9 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     const abortController = new AbortController();
     agent.abortController = abortController;
 
-    // Start elapsed timer
+    // Start elapsed timer — pauses while agent is idle
     agent.timer = setInterval(() => {
-      agent.elapsed++;
+      if (!agent.idle) agent.elapsed++;
       setAgents((prev) => [...prev]);
     }, 1000);
 


### PR DESCRIPTION
## Summary

The runtime clock displayed in the TUI continued ticking even when an agent was in the `idle` state, giving a misleading view of how long the agent was actively working.

The timer interval now checks `agent.idle` before incrementing `agent.elapsed`, so the clock only advances while the agent is actively running.

## Changes

- Skip `agent.elapsed` increment in the timer callback when `agent.idle` is `true`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.