### PR TITLE
🦌 Enable mouse scroll wheel support in tmux pane

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -113,6 +113,8 @@ export async function launchSandbox(options: SandboxOptions): Promise<SandboxSes
   const tmuxSettings: [string, string][] = [
     // Keep pane alive after command exits so we can capture scrollback
     ["remain-on-exit", "on"],
+    // Enable mouse scroll wheel support (enters copy mode automatically)
+    ["mouse", "on"],
     // Status bar with detach instructions
     ["status", "on"],
     ["status-position", "bottom"],


### PR DESCRIPTION
## Summary

Enables vertical scrolling with the mouse wheel when attached to a deer agent's tmux pane. This is achieved by setting `mouse on` in the tmux pane options, which causes tmux to automatically enter copy mode when the scroll wheel is used — allowing the user to scroll through agent output without any additional configuration.

## Changes

- Set `mouse on` tmux option when launching sandbox sessions, enabling scroll wheel support in attached panes

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.