### PR TITLE
🦌 Remove scroll key hint from tmux status bar

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -120,7 +120,7 @@ export async function launchSandbox(options: SandboxOptions): Promise<SandboxSes
     ["status-position", "bottom"],
     ["status-style", "#{?client_prefix,bg=#4a4a6e fg=#ffffff,bg=#1a1a2e fg=#e0e0e0}"],
     ["status-left", ""],
-    ["status-right", " 🦌 deer | Ctrl+b [ to scroll | Ctrl+b d to detach "],
+    ["status-right", " 🦌 deer | Ctrl+b d to detach "],
     ["status-right-style", "#{?client_prefix,bg=#4a4a6e fg=#ffffff,bg=#1a1a2e fg=#888888}"],
     ["status-justify", "left"],
   ];


### PR DESCRIPTION
## Summary

Now that mouse scroll is supported in tmux panes, the `Ctrl+b [` copy-mode scroll instruction in the status bar is no longer needed and has been removed to reduce clutter.

## Changes

- Removed `Ctrl+b [ to scroll` hint from the tmux status-right bar in `src/sandbox/index.ts`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.