### PR TITLE
🦌 Fix Update PR action using stale agent handle

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,7 +7,7 @@
 
 import { join, resolve } from "node:path";
 import { createWorktree, removeWorktree } from "./git/worktree";
-import { createPullRequest, updatePullRequest, cleanupWorktree } from "./git/finalize";
+import { createPullRequest, cleanupWorktree } from "./git/finalize";
 import type { CreatePRResult } from "./git/finalize";
 import { launchSandbox, isTmuxSessionDead, captureTmuxPane } from "./sandbox/index";
 import type { SandboxSession, SandboxRuntime } from "./sandbox/index";
@@ -245,25 +245,6 @@ export async function createAgentPR(
   });
 }
 
-/**
- * Push new commits and update the title/body of an existing PR.
- */
-export async function updateAgentPR(
-  handle: AgentHandle,
-  repoPath: string,
-  baseBranch: string,
-  prompt: string,
-  prUrl: string,
-): Promise<void> {
-  return updatePullRequest({
-    repoPath,
-    worktreePath: handle.worktreePath,
-    finalBranch: handle.branch,
-    baseBranch,
-    prompt,
-    prUrl,
-  });
-}
 
 /**
  * Get the last N lines of tmux output for an agent.

--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -177,7 +177,7 @@ export async function createPullRequest(options: CreatePROptions): Promise<Creat
   };
 }
 
-export interface UpdatePROptions {
+export interface PushBranchOptions {
   worktreePath: string;
   /** @example "deer/fix-login-redirect" */
   branch: string;
@@ -187,7 +187,7 @@ export interface UpdatePROptions {
  * Push new commits (and any uncommitted changes) from the worktree to the
  * existing remote branch, updating the open PR without creating a new one.
  */
-export async function pushBranchUpdates(options: UpdatePROptions): Promise<void> {
+export async function pushBranchUpdates(options: PushBranchOptions): Promise<void> {
   const { worktreePath, branch } = options;
 
   // Remove deer internal files before staging

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -6,7 +6,8 @@ import { upsertHistory, removeFromHistory, dataDir } from "../task";
 import type { PersistedTask } from "../task";
 import type { DeerConfig } from "../config";
 import type { PreflightResult } from "../preflight";
-import { startAgent, destroyAgent, deleteTask, createAgentPR, updateAgentPR } from "../agent";
+import { startAgent, destroyAgent, deleteTask, createAgentPR } from "../agent";
+import { updatePullRequest } from "../git/finalize";
 import { isTmuxSessionDead, captureTmuxPane } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";
 import { transition } from "../state-machine";
@@ -317,25 +318,28 @@ export function useAgentActions({
   // ── Update PR ─────────────────────────────────────────────────────
 
   const updatePr = useCallback(async (agent: AgentState) => {
-    if (!agent.handle || !agent.result?.prUrl) return;
+    if (!agent.result?.prUrl || !agent.result?.finalBranch) return;
 
-    agent.creatingPr = true;
+    const worktreePath = `${dataDir()}/tasks/${agent.taskId}/worktree`;
+
+    agent.updatingPr = true;
     agent.lastActivity = "Updating PR...";
     setAgents((prev) => [...prev]);
 
     try {
-      await updateAgentPR(
-        agent.handle,
-        cwd,
-        agent.baseBranch,
-        agent.prompt,
-        agent.result.prUrl,
-      );
+      await updatePullRequest({
+        repoPath: cwd,
+        worktreePath,
+        finalBranch: agent.result.finalBranch,
+        baseBranch: agent.baseBranch,
+        prompt: agent.prompt,
+        prUrl: agent.result.prUrl,
+      });
       agent.lastActivity = "PR updated";
     } catch (err) {
       agent.lastActivity = `PR update failed: ${err instanceof Error ? err.message : String(err)}`;
     } finally {
-      agent.creatingPr = false;
+      agent.updatingPr = false;
     }
     await saveToHistory(agent, cwd);
     setAgents((prev) => [...prev]);


### PR DESCRIPTION
## Summary

The "Update PR" action was silently failing because it relied on `agent.handle` (which is `null` after an agent finishes) to get the worktree path and branch. Since completed agents no longer have a live handle, the early return guard fired immediately and nothing happened.

The fix derives the worktree path directly from the known data directory convention and reads the branch from `agent.result.finalBranch`, which is persisted after agent completion.

## Changes

- `useAgentActions.ts`: Guard now checks `agent.result.prUrl` and `agent.result.finalBranch` instead of `agent.handle`; worktree path derived from `dataDir()` directly; calls `updatePullRequest` from `git/finalize` directly instead of through the removed `updateAgentPR` wrapper; uses `agent.updatingPr` flag instead of `agent.creatingPr`
- `agent.ts`: Removed `updateAgentPR` wrapper function (no longer needed)
- `git/finalize.ts`: Renamed `UpdatePROptions` → `PushBranchOptions` for clarity

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.