### PR TITLE
🦌 Fix tasks not re-acquired on deer restart

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -41,7 +41,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   const guardRef = useRef<ClaudeConfigGuard | null>(null);
   const configRef = useRef<DeerConfig | null>(null);
 
-  const { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef } = useAgentSync(cwd, configRef);
+  const { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory } = useAgentSync(cwd, configRef);
 
   const {
     promptHistory,
@@ -101,7 +101,12 @@ export default function Dashboard({ cwd }: { cwd: string }) {
 
   useEffect(() => {
     runPreflight().then(setPreflight);
-    loadConfig(cwd).then((cfg) => { configRef.current = cfg; });
+    loadConfig(cwd).then((cfg) => {
+      configRef.current = cfg;
+      // Re-run sync immediately so bwrap proxies are restored for any
+      // running cross-instance tasks without waiting for the 2s poll.
+      syncWithHistory();
+    });
     startClaudeConfigGuard((alert) => {
       setConfigAlerts((prev) => [...prev, alert]);
     }).then((guard) => {
@@ -113,10 +118,11 @@ export default function Dashboard({ cwd }: { cwd: string }) {
 
   useEffect(() => {
     const cleanup = () => {
+      // Abort deer's own polling loops so state updates stop, but leave the
+      // tmux sessions alive so agents continue running after a restart.
       for (const agent of agentsRef.current) {
-        if (isActive(agent) && agent.handle) {
+        if (isActive(agent)) {
           agent.abortController?.abort();
-          agent.handle.kill().catch(() => {});
         }
       }
       for (const proxyCleanup of restoredProxiesRef.current.values()) {

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -100,5 +100,5 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
     return () => clearInterval(interval);
   }, [syncWithHistory]);
 
-  return { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef };
+  return { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory };
 }


### PR DESCRIPTION
## Summary

When restarting deer, previously running tasks were not re-acquired — they appeared as `!` (error state) instead of resuming their active status. This happened because the initial config load completed before `syncWithHistory` ran, and on cleanup deer was killing agent handles instead of just stopping its own polling.

## Changes

- Expose `syncWithHistory` from `useAgentSync` so it can be called imperatively
- Call `syncWithHistory()` immediately after config loads on startup, so bwrap proxies and running tasks are restored without waiting for the 2s poll interval
- On cleanup, abort polling loops but do **not** kill agent tmux sessions — agents continue running after a restart
- Remove the `agent.handle.kill()` call on cleanup so in-flight agents are not terminated when deer exits

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.