### PR TITLE
🦌 Disable XON/XOFF flow control to prevent Claude stalling on tmux attac

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -122,7 +122,8 @@ export async function launchSandbox(options: SandboxOptions): Promise<SandboxSes
     .map(([k, v]) => `export ${k}='${v.replace(/'/g, "'\\''")}'`)
     .join("; ");
 
-  const preamble = `${envExports}; unset CLAUDECODE; exec ${escapedCmd}`;
+  // Disable XON/XOFF flow control so attaching a terminal client cannot stall Claude's output.
+  const preamble = `${envExports}; unset CLAUDECODE; stty -ixon 2>/dev/null || true; exec ${escapedCmd}`;
 
   // Create tmux session with a clean environment (env -i).
   // The preamble re-exports only the allowed vars.


### PR DESCRIPTION
## Summary

When attaching a terminal client to a running tmux session, XON/XOFF software flow control could cause Claude's output to stall. This happens because attaching a terminal that sends an XOFF signal (Ctrl+S) pauses output from the process, making it appear as though Claude has frozen.

## Changes

- Added `stty -ixon` to the tmux session preamble to disable XON/XOFF flow control before launching Claude, preventing any attached terminal from being able to stall output

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.