### PR TITLE
🦌 Fix cross-instance tasks stuck in running after restart

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -99,17 +99,23 @@ export function historicalAgent(task: PersistedTask, id: number): AgentState {
  * Convert a persisted "running" task to an AgentState for a task managed by
  * another deer instance. The tmux session is still alive, so this shows the
  * task as running and provides a handle for attaching and killing.
+ *
+ * @param idle - Whether the pane has been stable long enough to be considered idle
  */
-export function crossInstanceAgent(task: PersistedTask, id: number): AgentState {
+export function crossInstanceAgent(task: PersistedTask, id: number, idle = false): AgentState {
   const sessionName = `deer-${task.taskId}`;
   const worktreePath = join(dataDir(), "tasks", task.taskId, "worktree");
+  const lastActivity = idle
+    ? "Idle — press ⏎ to attach"
+    : (task.lastActivity || "Running in another instance...");
   return createAgentState({
     id,
     taskId: task.taskId,
     prompt: task.prompt,
     status: "running",
     elapsed: task.elapsed,
-    lastActivity: task.lastActivity || "Running in another instance...",
+    lastActivity,
+    idle,
     historical: true,
     handle: {
       taskId: task.taskId,

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -2,12 +2,13 @@ import { join } from "node:path";
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { MutableRefObject } from "react";
 import { loadHistory, dataDir } from "../task";
-import { isTmuxSessionDead } from "../sandbox/index";
+import { isTmuxSessionDead, captureTmuxPane } from "../sandbox/index";
 import type { SandboxCleanup } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";
 import { detectRepo } from "../git/worktree";
 import { type AgentState, historicalAgent, crossInstanceAgent } from "../agent-state";
 import type { DeerConfig } from "../config";
+import { stripAnsi, IDLE_THRESHOLD } from "../dashboard-utils";
 
 export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig | null>) {
   const [agents, setAgents] = useState<AgentState[]>([]);
@@ -18,6 +19,8 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
   const baseBranchRef = useRef("main");
   /** Proxy cleanup functions for cross-instance tasks restored after a restart */
   const restoredProxiesRef = useRef(new Map<string, SandboxCleanup>());
+  /** Pane snapshot state for idle detection on cross-instance tasks */
+  const crossInstancePaneStateRef = useRef(new Map<string, { snapshot: string; unchangedCount: number }>());
 
   // ── Detect base branch on mount ────────────────────────────────────
 
@@ -57,14 +60,33 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
             const cleanup = await runtime.restoreProxy?.(worktreePath, configRef.current.network.allowlist);
             if (cleanup) restoredProxiesRef.current.set(task.taskId, cleanup);
           }
-          return crossInstanceAgent(task, id);
+
+          // Detect idle by comparing consecutive pane snapshots across sync ticks
+          const sessionName = `deer-${task.taskId}`;
+          const lines = await captureTmuxPane(sessionName);
+          let idle = false;
+          if (lines) {
+            const snapshot = lines.map(stripAnsi).map((l) => l.trim()).filter(Boolean).join("\n");
+            const paneState = crossInstancePaneStateRef.current.get(task.taskId) ?? { snapshot: "", unchangedCount: 0 };
+            if (snapshot === paneState.snapshot) {
+              paneState.unchangedCount++;
+            } else {
+              paneState.unchangedCount = 0;
+              paneState.snapshot = snapshot;
+            }
+            crossInstancePaneStateRef.current.set(task.taskId, paneState);
+            idle = paneState.unchangedCount >= IDLE_THRESHOLD;
+          }
+
+          return crossInstanceAgent(task, id, idle);
         }
-        // Session died — stop any proxy we restored for this task
+        // Session died — stop any proxy we restored for this task and clear pane state
         const proxyCleanup = restoredProxiesRef.current.get(task.taskId);
         if (proxyCleanup) {
           proxyCleanup();
           restoredProxiesRef.current.delete(task.taskId);
         }
+        crossInstancePaneStateRef.current.delete(task.taskId);
         // Fall through to historicalAgent (shows as interrupted)
       }
 
@@ -81,7 +103,7 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       newAgents.length !== currentAgents.length ||
       newAgents.some((a, i) => {
         const cur = currentAgents[i];
-        return !cur || a.taskId !== cur.taskId || a.status !== cur.status || a.lastActivity !== cur.lastActivity;
+        return !cur || a.taskId !== cur.taskId || a.status !== cur.status || a.lastActivity !== cur.lastActivity || a.idle !== cur.idle;
       });
 
     if (changed) setAgents(newAgents);

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -177,4 +177,28 @@ describe("crossInstanceAgent", () => {
     const agent = crossInstanceAgent(task, 1);
     expect(agent.elapsed).toBe(42);
   });
+
+  test("idle defaults to false", () => {
+    const task = makeTask({ status: "running", completedAt: null });
+    const agent = crossInstanceAgent(task, 1);
+    expect(agent.idle).toBe(false);
+  });
+
+  test("idle is set to true when passed", () => {
+    const task = makeTask({ status: "running", completedAt: null });
+    const agent = crossInstanceAgent(task, 1, true);
+    expect(agent.idle).toBe(true);
+  });
+
+  test("lastActivity is idle message when idle=true", () => {
+    const task = makeTask({ status: "running", completedAt: null, lastActivity: "Working..." });
+    const agent = crossInstanceAgent(task, 1, true);
+    expect(agent.lastActivity).toBe("Idle — press ⏎ to attach");
+  });
+
+  test("lastActivity preserved from task when not idle", () => {
+    const task = makeTask({ status: "running", completedAt: null, lastActivity: "Working..." });
+    const agent = crossInstanceAgent(task, 1, false);
+    expect(agent.lastActivity).toBe("Working...");
+  });
 });


### PR DESCRIPTION
## Summary

When deer restarts, tasks with active tmux sessions were always shown as "running" even when idle. Idle detection relies on monitoring tmux pane output for changes, but on restart the pane state was never captured — only live incoming output was tracked.

This fix captures tmux pane snapshots during the sync loop for cross-instance tasks, running them through the same ANSI-strip and trim filtering as live output. Consecutive identical snapshots increment a counter, and once the threshold is reached the task is marked idle.

## Changes

- `useAgentSync`: capture tmux pane snapshot each sync tick for cross-instance tasks; track per-task `{ snapshot, unchangedCount }` in a ref; pass `idle` flag to `crossInstanceAgent`
- `crossInstanceAgent`: accept optional `idle` parameter (default `false`); set `lastActivity` to `"Idle — press ⏎ to attach"` when idle
- Clear per-task pane state when a session is found to be dead
- Include `idle` in the change-detection comparison to avoid missed re-renders
- Add tests for `idle` flag behaviour on `crossInstanceAgent`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.