### PR TITLE
🦌 Move confirmation banners to top of dashboard

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -180,6 +180,20 @@ export default function Dashboard({ cwd }: { cwd: string }) {
       </Box>
       <Text>{"─".repeat(termWidth)}</Text>
 
+      {/* Confirmation banners */}
+      {pendingConfirmation && (
+        <Box paddingX={1}>
+          <Text color="yellow" bold>{pendingConfirmation.message}</Text>
+        </Box>
+      )}
+      {confirmQuit && (
+        <Box paddingX={1}>
+          <Text color="yellow" bold>
+            {activeCount} agent{activeCount !== 1 ? "s" : ""} running — quit? (y/n)
+          </Text>
+        </Box>
+      )}
+
       {/* Preflight errors */}
       {preflight && !preflight.ok && (
         <Box flexDirection="column" paddingX={1}>
@@ -358,14 +372,6 @@ export default function Dashboard({ cwd }: { cwd: string }) {
               <Text dimColor>⏎ select</Text>
               <Text dimColor>Esc cancel</Text>
             </>
-          ) : pendingConfirmation ? (
-            <Text color="yellow" bold>
-              {pendingConfirmation.message}
-            </Text>
-          ) : confirmQuit ? (
-            <Text color="yellow" bold>
-              {activeCount} agent{activeCount !== 1 ? "s" : ""} running — quit? (y/n)
-            </Text>
           ) : (
             <>
               <Text dimColor>Tab focus</Text>


### PR DESCRIPTION
## Summary

Confirmation prompts (pending confirmation and quit confirmation) were displayed at the bottom of the dashboard in the status bar area, making them easy to miss. They are now rendered near the top of the screen, just below the header divider.

## Changes

- Removed confirmation prompt rendering from the bottom status bar area
- Added confirmation banners at the top of the dashboard content area, below the header rule
- Both `pendingConfirmation` and `confirmQuit` banners now appear prominently at the top

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.