### PR TITLE
🦌 Fix tmux log display for cross-instance agents on restart

### DIFF
--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -8,7 +8,7 @@ import { resolveRuntime } from "../sandbox/resolve";
 import { detectRepo } from "../git/worktree";
 import { type AgentState, historicalAgent, crossInstanceAgent } from "../agent-state";
 import type { DeerConfig } from "../config";
-import { stripAnsi, IDLE_THRESHOLD } from "../dashboard-utils";
+import { stripAnsi, IDLE_THRESHOLD, MAX_LOG_LINES, truncate } from "../dashboard-utils";
 
 export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig | null>) {
   const [agents, setAgents] = useState<AgentState[]>([]);
@@ -65,6 +65,8 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
           const sessionName = `deer-${task.taskId}`;
           const lines = await captureTmuxPane(sessionName);
           let idle = false;
+          // Carry over logs from the previous sync so they aren't lost on each tick
+          let logs: string[] = existing?.logs ?? [];
           if (lines) {
             const snapshot = lines.map(stripAnsi).map((l) => l.trim()).filter(Boolean).join("\n");
             const paneState = crossInstancePaneStateRef.current.get(task.taskId) ?? { snapshot: "", unchangedCount: 0 };
@@ -73,12 +75,29 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
             } else {
               paneState.unchangedCount = 0;
               paneState.snapshot = snapshot;
+
+              // Append new activity to logs when pane content changes (same logic as locally-managed agents)
+              const activityLine = lines
+                .map(stripAnsi)
+                .map((l) => l.trim())
+                .filter((l) => l.startsWith("●"))
+                .pop();
+              if (activityLine) {
+                logs = [...logs, `[tmux] ${truncate(activityLine, 200)}`];
+                if (logs.length > MAX_LOG_LINES) logs = logs.slice(-MAX_LOG_LINES);
+              } else if (logs.length === 0) {
+                // Initial load after restart: populate with the current visible pane content
+                logs = lines.map(stripAnsi).filter((l) => l.trim());
+                if (logs.length > MAX_LOG_LINES) logs = logs.slice(-MAX_LOG_LINES);
+              }
             }
             crossInstancePaneStateRef.current.set(task.taskId, paneState);
             idle = paneState.unchangedCount >= IDLE_THRESHOLD;
           }
 
-          return crossInstanceAgent(task, id, idle);
+          const agent = crossInstanceAgent(task, id, idle);
+          agent.logs = logs;
+          return agent;
         }
         // Session died — stop any proxy we restored for this task and clear pane state
         const proxyCleanup = restoredProxiesRef.current.get(task.taskId);
@@ -103,7 +122,7 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       newAgents.length !== currentAgents.length ||
       newAgents.some((a, i) => {
         const cur = currentAgents[i];
-        return !cur || a.taskId !== cur.taskId || a.status !== cur.status || a.lastActivity !== cur.lastActivity || a.idle !== cur.idle;
+        return !cur || a.taskId !== cur.taskId || a.status !== cur.status || a.lastActivity !== cur.lastActivity || a.idle !== cur.idle || a.logs.length !== cur.logs.length;
       });
 
     if (changed) setAgents(newAgents);


### PR DESCRIPTION
## Summary

When reopening deer or attaching from a new window, the tmux pane log was not appearing beneath tasks in the TUI. Idle detection worked correctly because it used pane state comparison, but logs were being dropped on each sync tick since cross-instance agents were reconstructed without carrying over accumulated log lines.

The fix preserves logs across sync ticks by seeding new agent state from the previous sync's logs, and populates an initial log snapshot on first load after restart. The change equality check was also updated to trigger a re-render when log lines change.

Confirmation banners were also moved from the main body area into the footer keybinding bar so they appear inline with other status messages rather than as floating banners.

## Changes

- `useAgentSync.ts`: Carry over `existing?.logs` into each sync tick so logs persist across ticks for cross-instance agents
- `useAgentSync.ts`: On initial load (empty logs), populate from current visible pane content as a baseline
- `useAgentSync.ts`: Append `●`-prefixed activity lines from pane captures to logs when pane content changes (mirrors locally-managed agent logic)
- `useAgentSync.ts`: Include `logs.length` in the agent equality check so log updates trigger a re-render
- `dashboard.tsx`: Move `pendingConfirmation` and `confirmQuit` banners into the footer keybinding area instead of rendering them above the task list

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.