### PR TITLE
🦌 Fix PR generation polluting Claude project history

### DIFF
--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -128,6 +128,8 @@ ${truncatedDiff}`;
       stdout: "pipe",
       stderr: "pipe",
       timeout: 60_000,
+      // Run in /tmp so this doesn't pollute the user's project history in ~/.claude/projects/
+      cwd: "/tmp",
     });
     const exitCode = await proc.exited;
     if (exitCode !== 0) throw new Error("claude exited with non-zero status");


### PR DESCRIPTION
## Summary

Running `claude` to generate PR descriptions was being tracked in the user's Claude project history (under `~/.claude/projects/`) because it ran in the project's working directory. Fixed by running the subprocess in `/tmp` so it is associated with a neutral path and doesn't appear in the user's normal resume history.

Also includes several cleanup and improvement changes that landed in the same session:
- Replaced the `pane-idle.ts` abstraction with inline variables in the poll loop
- Simplified the post-detach idle detection to a single pane capture
- Moved confirmation banners into the bottom status bar area
- Rewrote Shift+Enter handling to use explicit Kitty keyboard protocol negotiation on stdin instead of relying on Ink's built-in detection, fixing double-insertion issues

## Changes

- `src/git/finalize.ts`: Set `cwd: "/tmp"` on the `claude` subprocess used for PR description generation
- `src/pane-idle.ts`: Deleted — logic inlined into `useAgentActions`
- `src/hooks/useAgentActions.ts`: Replaced `paneStateRef` map with local `lastPaneSnapshot`/`unchangedCount` variables; simplified post-detach activity update
- `src/dashboard.tsx`: Moved confirmation banners from above preflight errors into the bottom keybinding bar
- `src/kitty-input.ts`: New module handling Kitty protocol sequences (Shift+Enter, Backspace)
- `src/components/PromptInput.tsx`: Added `useEffect` to negotiate Kitty protocol and handle raw stdin sequences via `applyKittyData`
- `test/dashboard.test.ts`: Added `applyKittyData` unit tests
- `test/pane-idle.test.ts`: Deleted alongside `pane-idle.ts`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.