### PR TITLE
🦌 Replace cross-instance polling with live state files

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { dataDir } from "./task";
 import type { PersistedTask } from "./task";
+import type { TaskStateFile } from "./task-state";
 import type { AgentState as AgentStatus } from "./state-machine";
 import type { AgentHandle } from "./agent";
 
@@ -96,32 +97,31 @@ export function historicalAgent(task: PersistedTask, id: number): AgentState {
 }
 
 /**
- * Convert a persisted "running" task to an AgentState for a task managed by
- * another deer instance. The tmux session is still alive, so this shows the
- * task as running and provides a handle for attaching and killing.
- *
- * @param idle - Whether the pane has been stable long enough to be considered idle
+ * Build an AgentState from a live task-state file for a task managed by
+ * another deer instance. Includes full logs, idle status, and elapsed
+ * as written by the owning instance.
  */
-export function crossInstanceAgent(task: PersistedTask, id: number, idle = false): AgentState {
-  const sessionName = `deer-${task.taskId}`;
-  const worktreePath = join(dataDir(), "tasks", task.taskId, "worktree");
-  const lastActivity = idle
-    ? "Idle — press ⏎ to attach"
-    : (task.lastActivity || "Running in another instance...");
+export function liveTaskFromStateFile(stateFile: TaskStateFile, id: number): AgentState {
+  const sessionName = `deer-${stateFile.taskId}`;
+  const worktreePath = join(dataDir(), "tasks", stateFile.taskId, "worktree");
   return createAgentState({
     id,
-    taskId: task.taskId,
-    prompt: task.prompt,
+    taskId: stateFile.taskId,
+    prompt: stateFile.prompt,
     status: "running",
-    elapsed: task.elapsed,
-    lastActivity,
-    idle,
+    elapsed: stateFile.elapsed,
+    lastActivity: stateFile.lastActivity,
+    logs: [...stateFile.logs],
+    idle: stateFile.idle,
     historical: true,
+    result: stateFile.prUrl
+      ? { finalBranch: stateFile.finalBranch ?? "", prUrl: stateFile.prUrl }
+      : null,
     handle: {
-      taskId: task.taskId,
+      taskId: stateFile.taskId,
       sessionName,
       worktreePath,
-      branch: task.finalBranch ?? `deer/${task.taskId}`,
+      branch: stateFile.finalBranch ?? `deer/${stateFile.taskId}`,
       async kill() {
         await Bun.spawn(
           ["tmux", "kill-session", "-t", sessionName],
@@ -129,5 +129,26 @@ export function crossInstanceAgent(task: PersistedTask, id: number, idle = false
         ).exited;
       },
     },
+  });
+}
+
+/**
+ * Build an AgentState from a state file whose owning process has died.
+ * Shows the task as interrupted with its last known state.
+ */
+export function historicalAgentFromStateFile(stateFile: TaskStateFile, id: number): AgentState {
+  return createAgentState({
+    id,
+    taskId: stateFile.taskId,
+    prompt: stateFile.prompt,
+    status: "interrupted",
+    elapsed: stateFile.elapsed,
+    lastActivity: "Interrupted — deer was closed",
+    logs: [...stateFile.logs],
+    result: stateFile.prUrl
+      ? { finalBranch: stateFile.finalBranch ?? "", prUrl: stateFile.prUrl }
+      : null,
+    error: stateFile.error || "",
+    historical: true,
   });
 }

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -4,6 +4,8 @@ import type { AgentState } from "../agent-state";
 import { createAgentState } from "../agent-state";
 import { upsertHistory, removeFromHistory, dataDir } from "../task";
 import type { PersistedTask } from "../task";
+import { writeTaskState, removeTaskState } from "../task-state";
+import type { TaskStateFile } from "../task-state";
 import type { DeerConfig } from "../config";
 import type { PreflightResult } from "../preflight";
 import { startAgent, destroyAgent, deleteTask, createAgentPR } from "../agent";
@@ -21,6 +23,23 @@ import {
   POLL_MS,
   IDLE_THRESHOLD,
 } from "../dashboard-utils";
+
+function toTaskStateFile(agent: AgentState): TaskStateFile {
+  return {
+    taskId: agent.taskId,
+    prompt: agent.prompt,
+    status: agent.status as TaskStateFile["status"],
+    elapsed: agent.elapsed,
+    lastActivity: agent.lastActivity,
+    finalBranch: agent.result?.finalBranch ?? null,
+    prUrl: agent.result?.prUrl ?? null,
+    error: agent.error || null,
+    logs: [...agent.logs],
+    idle: agent.idle,
+    createdAt: new Date(Date.now() - agent.elapsed * 1000).toISOString(),
+    ownerPid: process.pid,
+  };
+}
 
 async function saveToHistory(agent: AgentState, repoPath: string): Promise<void> {
   if (agent.historical) return;
@@ -84,6 +103,7 @@ export function useAgentActions({
     // Start elapsed timer — pauses while agent is idle
     agent.timer = setInterval(() => {
       if (!agent.idle) agent.elapsed++;
+      if (agent.taskId) writeTaskState(toTaskStateFile(agent)).catch(() => {});
       setAgents((prev) => [...prev]);
     }, 1000);
 
@@ -114,19 +134,8 @@ export function useAgentActions({
       agent.handle = handle;
       agent.taskId = handle.taskId;
 
-      // Persist immediately so the task survives if deer closes
-      await upsertHistory(cwd, {
-        taskId: agent.taskId,
-        prompt: agent.prompt,
-        status: "running",
-        createdAt: new Date().toISOString(),
-        completedAt: null,
-        elapsed: 0,
-        prUrl: null,
-        finalBranch: null,
-        error: null,
-        lastActivity: "",
-      });
+      // Write live state file so other deer instances can observe this task
+      await writeTaskState(toTaskStateFile(agent));
 
       agent.status = transition(agent.status, "SETUP_COMPLETE") ?? agent.status;
       appendLog(agent, `[running] Claude started in tmux session: ${handle.sessionName}`);
@@ -168,19 +177,7 @@ export function useAgentActions({
               if (activity !== agent.lastActivity) {
                 agent.lastActivity = activity;
                 appendLog(agent, `[tmux] ${truncate(lastOutput, 200)}`);
-                // Persist progress so other deer instances see the current activity
-                await upsertHistory(cwd, {
-                  taskId: agent.taskId,
-                  prompt: agent.prompt,
-                  status: "running",
-                  createdAt: new Date(Date.now() - agent.elapsed * 1000).toISOString(),
-                  completedAt: null,
-                  elapsed: agent.elapsed,
-                  prUrl: null,
-                  finalBranch: null,
-                  error: null,
-                  lastActivity: agent.lastActivity,
-                });
+                await writeTaskState(toTaskStateFile(agent));
                 setAgents((prev) => [...prev]);
               }
             }
@@ -191,9 +188,11 @@ export function useAgentActions({
             agent.idle = true;
             agent.lastActivity = "Idle — press ⏎ to attach";
             appendLog(agent, "[deer] Claude is idle");
+            await writeTaskState(toTaskStateFile(agent));
             setAgents((prev) => [...prev]);
           } else if (unchangedCount === 0 && agent.idle) {
             agent.idle = false;
+            await writeTaskState(toTaskStateFile(agent));
             setAgents((prev) => [...prev]);
           }
         }
@@ -217,6 +216,8 @@ export function useAgentActions({
       if (!agent.deleted) {
         await saveToHistory(agent, cwd);
       }
+      // Remove the live state file — the JSONL history entry is now authoritative
+      await removeTaskState(agent.taskId).catch(() => {});
       setAgents((prev) => [...prev]);
     }
   }, [cwd, preflight]);
@@ -234,6 +235,7 @@ export function useAgentActions({
     if (agent.timer) clearInterval(agent.timer);
     agent.timer = null;
     saveToHistory(agent, cwd);
+    writeTaskState(toTaskStateFile(agent)).catch(() => {});
     setAgents((prev) => [...prev]);
   }, [cwd]);
 

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -1,14 +1,14 @@
 import { join } from "node:path";
+import { watch } from "node:fs";
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { MutableRefObject } from "react";
 import { loadHistory, dataDir } from "../task";
-import { isTmuxSessionDead, captureTmuxPane } from "../sandbox/index";
 import type { SandboxCleanup } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";
 import { detectRepo } from "../git/worktree";
-import { type AgentState, historicalAgent, crossInstanceAgent } from "../agent-state";
+import { type AgentState, historicalAgent, liveTaskFromStateFile, historicalAgentFromStateFile } from "../agent-state";
+import { readTaskState, scanLiveTaskIds, isOwnerAlive } from "../task-state";
 import type { DeerConfig } from "../config";
-import { stripAnsi, IDLE_THRESHOLD } from "../dashboard-utils";
 
 export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig | null>) {
   const [agents, setAgents] = useState<AgentState[]>([]);
@@ -19,8 +19,6 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
   const baseBranchRef = useRef("main");
   /** Proxy cleanup functions for cross-instance tasks restored after a restart */
   const restoredProxiesRef = useRef(new Map<string, SandboxCleanup>());
-  /** Pane snapshot state for idle detection on cross-instance tasks */
-  const crossInstancePaneStateRef = useRef(new Map<string, { snapshot: string; unchangedCount: number }>());
 
   // ── Detect base branch on mount ────────────────────────────────────
 
@@ -30,71 +28,83 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
     }).catch(() => {});
   }, [cwd]);
 
-  // ── Sync state from history file ──────────────────────────────────
+  // ── Sync state from state files + history ──────────────────────────
 
   const syncWithHistory = useCallback(async () => {
+    // Live tasks: read state.json files written by owning deer instances
+    const liveTaskIds = await scanLiveTaskIds();
+    const liveStateFiles = new Map<string, Awaited<ReturnType<typeof readTaskState>>>();
+    for (const taskId of liveTaskIds) {
+      if (!deletedTaskIdsRef.current.has(taskId)) {
+        const state = await readTaskState(taskId);
+        if (state) liveStateFiles.set(taskId, state);
+      }
+    }
+
+    // Completed tasks: JSONL history (only non-running entries now that live tasks
+    // use state.json; running entries are kept as a fallback for tasks started by
+    // older deer versions that did not write state.json)
     const allFileTasks = await loadHistory(cwd);
     const fileTasks = allFileTasks.filter(t => !deletedTaskIdsRef.current.has(t.taskId));
+
     const currentAgents = agentsRef.current;
     const agentByTaskId = new Map(currentAgents.map(a => [a.taskId, a]));
-    const fileTaskIds = new Set(fileTasks.map(t => t.taskId));
 
-    const newAgents: AgentState[] = await Promise.all(fileTasks.map(async task => {
-      const existing = agentByTaskId.get(task.taskId);
+    // Union of all known task IDs
+    const allTaskIds = new Set([
+      ...liveStateFiles.keys(),
+      ...fileTasks.map(t => t.taskId),
+    ]);
+
+    const newAgents: AgentState[] = [];
+
+    for (const taskId of allTaskIds) {
+      const existing = agentByTaskId.get(taskId);
+
+      // Locally-managed (non-historical) agents are authoritative — keep as-is
       if (existing && !existing.historical) {
-        return existing;
+        newAgents.push(existing);
+        continue;
       }
+
       const id = existing?.id ?? nextId.current++;
+      const stateFile = liveStateFiles.get(taskId);
 
-      // For running tasks not managed by this instance, check if the tmux
-      // session is still alive to distinguish cross-instance tasks from
-      // truly interrupted ones.
-      if (task.status === "running") {
-        const isDead = await isTmuxSessionDead(`deer-${task.taskId}`);
-        if (!isDead) {
-          // Restore the bwrap proxy once per task so the sandbox can reach
-          // the Claude API after a deer restart.
-          if (!restoredProxiesRef.current.has(task.taskId) && configRef.current) {
+      if (stateFile) {
+        const ownerAlive = isOwnerAlive(stateFile.ownerPid);
+
+        if (ownerAlive && stateFile.ownerPid !== process.pid) {
+          // Cross-instance task: the owning deer process is still alive
+          if (!restoredProxiesRef.current.has(taskId) && configRef.current) {
             const runtime = resolveRuntime(configRef.current);
-            const worktreePath = join(dataDir(), "tasks", task.taskId, "worktree");
+            const worktreePath = join(dataDir(), "tasks", taskId, "worktree");
             const cleanup = await runtime.restoreProxy?.(worktreePath, configRef.current.network.allowlist);
-            if (cleanup) restoredProxiesRef.current.set(task.taskId, cleanup);
+            if (cleanup) restoredProxiesRef.current.set(taskId, cleanup);
           }
-
-          // Detect idle by comparing consecutive pane snapshots across sync ticks
-          const sessionName = `deer-${task.taskId}`;
-          const lines = await captureTmuxPane(sessionName);
-          let idle = false;
-          if (lines) {
-            const snapshot = lines.map(stripAnsi).map((l) => l.trim()).filter(Boolean).join("\n");
-            const paneState = crossInstancePaneStateRef.current.get(task.taskId) ?? { snapshot: "", unchangedCount: 0 };
-            if (snapshot === paneState.snapshot) {
-              paneState.unchangedCount++;
-            } else {
-              paneState.unchangedCount = 0;
-              paneState.snapshot = snapshot;
-            }
-            crossInstancePaneStateRef.current.set(task.taskId, paneState);
-            idle = paneState.unchangedCount >= IDLE_THRESHOLD;
-          }
-
-          return crossInstanceAgent(task, id, idle);
+          newAgents.push(liveTaskFromStateFile(stateFile, id));
+          continue;
         }
-        // Session died — stop any proxy we restored for this task and clear pane state
-        const proxyCleanup = restoredProxiesRef.current.get(task.taskId);
+
+        // Owner process died — clean up any restored proxy and show as interrupted
+        const proxyCleanup = restoredProxiesRef.current.get(taskId);
         if (proxyCleanup) {
           proxyCleanup();
-          restoredProxiesRef.current.delete(task.taskId);
+          restoredProxiesRef.current.delete(taskId);
         }
-        crossInstancePaneStateRef.current.delete(task.taskId);
-        // Fall through to historicalAgent (shows as interrupted)
+        newAgents.push(historicalAgentFromStateFile(stateFile, id));
+        continue;
       }
 
-      return historicalAgent(task, id);
-    }));
+      // No state.json — fall back to JSONL history entry
+      const fileTask = fileTasks.find(t => t.taskId === taskId);
+      if (fileTask) {
+        newAgents.push(historicalAgent(fileTask, id));
+      }
+    }
 
+    // Keep locally-owned agents that haven't written their state file yet
     for (const agent of currentAgents) {
-      if (!agent.historical && !fileTaskIds.has(agent.taskId)) {
+      if (!agent.historical && !allTaskIds.has(agent.taskId)) {
         newAgents.push(agent);
       }
     }
@@ -103,23 +113,52 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       newAgents.length !== currentAgents.length ||
       newAgents.some((a, i) => {
         const cur = currentAgents[i];
-        return !cur || a.taskId !== cur.taskId || a.status !== cur.status || a.lastActivity !== cur.lastActivity || a.idle !== cur.idle;
+        return !cur ||
+          a.taskId !== cur.taskId ||
+          a.status !== cur.status ||
+          a.lastActivity !== cur.lastActivity ||
+          a.idle !== cur.idle ||
+          a.elapsed !== cur.elapsed ||
+          a.logs.length !== cur.logs.length;
       });
 
     if (changed) setAgents(newAgents);
   }, [cwd]);
 
-  // ── Load history on mount ──────────────────────────────────────────
+  // ── Load on mount ──────────────────────────────────────────────────
 
   useEffect(() => {
     syncWithHistory();
   }, [syncWithHistory]);
 
-  // ── Poll history file for changes from other deer instances ────────
+  // ── Watch tasks directory for instant cross-instance updates ───────
 
   useEffect(() => {
-    const interval = setInterval(syncWithHistory, 2_000);
-    return () => clearInterval(interval);
+    const tasksDir = join(dataDir(), "tasks");
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const trigger = () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(syncWithHistory, 100);
+    };
+
+    let watcher: ReturnType<typeof watch> | null = null;
+    try {
+      watcher = watch(tasksDir, { recursive: true }, (_, filename) => {
+        if (filename?.endsWith("state.json")) trigger();
+      });
+    } catch {
+      // tasks dir may not exist yet — the slow poll below provides fallback
+    }
+
+    // Safety-net poll in case fs.watch misses events (e.g. on some Linux setups)
+    const interval = setInterval(syncWithHistory, 10_000);
+
+    return () => {
+      watcher?.close();
+      clearInterval(interval);
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
   }, [syncWithHistory]);
 
   return { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory };

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -1,0 +1,124 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { dataDir } from "./task";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+/**
+ * Live state for a running task, written to disk by the owning deer instance
+ * and read by any other instances watching the same tasks directory.
+ *
+ * Stored at: ~/.local/share/deer/tasks/<taskId>/state.json
+ */
+export interface TaskStateFile {
+  /** @example "deer_01jm8k3nxa7f" */
+  taskId: string;
+  prompt: string;
+  status: "running" | "failed" | "cancelled";
+  /** Elapsed seconds (paused while idle) */
+  elapsed: number;
+  /** Latest activity line shown in the TUI */
+  lastActivity: string;
+  /** @example "deer/deer_01jm8k3nxa7f" */
+  finalBranch: string | null;
+  /** @example "https://github.com/org/repo/pull/42" */
+  prUrl: string | null;
+  error: string | null;
+  /** Capped ring buffer of recent log lines */
+  logs: string[];
+  /** True when Claude is idle (waiting for user input) */
+  idle: boolean;
+  /** ISO 8601 timestamp */
+  createdAt: string;
+  /** PID of the deer process that owns this task */
+  ownerPid: number;
+}
+
+// ── Paths ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns the state file path for a task.
+ * @example "/home/user/.local/share/deer/tasks/deer_xxx/state.json"
+ */
+export function taskStatePath(taskId: string): string {
+  return join(dataDir(), "tasks", taskId, "state.json");
+}
+
+// ── Read / Write / Remove ─────────────────────────────────────────────
+
+/**
+ * Read the live state file for a task.
+ * Returns null if no state file exists (task is not live).
+ */
+export async function readTaskState(taskId: string): Promise<TaskStateFile | null> {
+  const file = Bun.file(taskStatePath(taskId));
+  if (!(await file.exists())) return null;
+  try {
+    return await file.json() as TaskStateFile;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the live state file for a task, creating the task directory if needed.
+ * Only the owning deer instance should call this.
+ */
+export async function writeTaskState(state: TaskStateFile): Promise<void> {
+  const path = taskStatePath(state.taskId);
+  await mkdir(join(dataDir(), "tasks", state.taskId), { recursive: true });
+  await Bun.write(path, JSON.stringify(state));
+}
+
+/**
+ * Remove the live state file for a task.
+ * Called when a task completes, fails, or is deleted.
+ */
+export async function removeTaskState(taskId: string): Promise<void> {
+  const path = taskStatePath(taskId);
+  try {
+    await Bun.$`rm -f ${path}`.quiet();
+  } catch {
+    // Ignore — file may already be gone
+  }
+}
+
+// ── Owner Detection ───────────────────────────────────────────────────
+
+/**
+ * Returns true if the process with the given PID is still running.
+ * Uses signal 0 which tests process existence without sending a real signal.
+ */
+export function isOwnerAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Directory Scan ────────────────────────────────────────────────────
+
+/**
+ * Scan the tasks directory for all taskIds that have a live state file.
+ * Returns an empty array if the directory does not exist.
+ */
+export async function scanLiveTaskIds(): Promise<string[]> {
+  const tasksDir = join(dataDir(), "tasks");
+  try {
+    const glob = new Bun.Glob("*/state.json");
+    const taskIds: string[] = [];
+    for await (const match of glob.scan({ cwd: tasksDir })) {
+      // match is like "deer_xxx/state.json" — extract the taskId
+      const taskId = match.replace("/state.json", "");
+      if (taskId.startsWith("deer_")) {
+        taskIds.push(taskId);
+      }
+    }
+    return taskIds;
+  } catch {
+    return [];
+  }
+}

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -1,7 +1,8 @@
 import { test, expect, describe } from "bun:test";
-import { historicalAgent, crossInstanceAgent, createAgentState } from "../src/agent-state";
+import { historicalAgent, liveTaskFromStateFile, historicalAgentFromStateFile, createAgentState } from "../src/agent-state";
 import { generateTaskId } from "../src/task";
 import type { PersistedTask } from "../src/task";
+import type { TaskStateFile } from "../src/task-state";
 import { fuzzyMatch } from "../src/fuzzy";
 import { applyKittyData } from "../src/kitty-input";
 
@@ -132,73 +133,118 @@ describe("historicalAgent", () => {
   });
 });
 
-describe("crossInstanceAgent", () => {
+function makeStateFile(overrides?: Partial<TaskStateFile>): TaskStateFile {
+  return {
+    taskId: generateTaskId(),
+    prompt: "fix the bug",
+    status: "running",
+    elapsed: 60,
+    lastActivity: "done",
+    finalBranch: null,
+    prUrl: null,
+    error: null,
+    logs: [],
+    idle: false,
+    createdAt: new Date().toISOString(),
+    ownerPid: process.pid,
+    ...overrides,
+  };
+}
+
+describe("liveTaskFromStateFile", () => {
   test("status is running", () => {
-    const task = makeTask({ status: "running", completedAt: null });
-    const agent = crossInstanceAgent(task, 1);
+    const agent = liveTaskFromStateFile(makeStateFile(), 1);
     expect(agent.status).toBe("running");
   });
 
   test("is marked as historical", () => {
-    const task = makeTask({ status: "running", completedAt: null });
-    const agent = crossInstanceAgent(task, 1);
+    const agent = liveTaskFromStateFile(makeStateFile(), 1);
     expect(agent.historical).toBe(true);
   });
 
   test("has a handle with correct sessionName", () => {
     const taskId = generateTaskId();
-    const task = makeTask({ taskId, status: "running", completedAt: null });
-    const agent = crossInstanceAgent(task, 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ taskId }), 1);
     expect(agent.handle).not.toBeNull();
     expect(agent.handle?.sessionName).toBe(`deer-${taskId}`);
   });
 
   test("handle taskId matches task taskId", () => {
     const taskId = generateTaskId();
-    const task = makeTask({ taskId, status: "running", completedAt: null });
-    const agent = crossInstanceAgent(task, 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ taskId }), 1);
     expect(agent.handle?.taskId).toBe(taskId);
   });
 
-  test("preserves lastActivity from task", () => {
-    const task = makeTask({ status: "running", completedAt: null, lastActivity: "Fixing bug..." });
-    const agent = crossInstanceAgent(task, 1);
+  test("preserves lastActivity from state file", () => {
+    const agent = liveTaskFromStateFile(makeStateFile({ lastActivity: "Fixing bug..." }), 1);
     expect(agent.lastActivity).toBe("Fixing bug...");
   });
 
-  test("uses default lastActivity when empty", () => {
-    const task = makeTask({ status: "running", completedAt: null, lastActivity: "" });
-    const agent = crossInstanceAgent(task, 1);
-    expect(agent.lastActivity.length).toBeGreaterThan(0);
-  });
-
-  test("elapsed matches task elapsed", () => {
-    const task = makeTask({ status: "running", completedAt: null, elapsed: 42 });
-    const agent = crossInstanceAgent(task, 1);
+  test("elapsed matches state file elapsed", () => {
+    const agent = liveTaskFromStateFile(makeStateFile({ elapsed: 42 }), 1);
     expect(agent.elapsed).toBe(42);
   });
 
   test("idle defaults to false", () => {
-    const task = makeTask({ status: "running", completedAt: null });
-    const agent = crossInstanceAgent(task, 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ idle: false }), 1);
     expect(agent.idle).toBe(false);
   });
 
-  test("idle is set to true when passed", () => {
-    const task = makeTask({ status: "running", completedAt: null });
-    const agent = crossInstanceAgent(task, 1, true);
+  test("idle is set to true when state file has idle=true", () => {
+    const agent = liveTaskFromStateFile(makeStateFile({ idle: true }), 1);
     expect(agent.idle).toBe(true);
   });
 
-  test("lastActivity is idle message when idle=true", () => {
-    const task = makeTask({ status: "running", completedAt: null, lastActivity: "Working..." });
-    const agent = crossInstanceAgent(task, 1, true);
-    expect(agent.lastActivity).toBe("Idle — press ⏎ to attach");
+  test("carries over logs from state file", () => {
+    const logs = ["[setup] Creating worktree...", "[running] Claude started", "● Fixing the issue"];
+    const agent = liveTaskFromStateFile(makeStateFile({ logs }), 1);
+    expect(agent.logs).toEqual(logs);
   });
 
-  test("lastActivity preserved from task when not idle", () => {
-    const task = makeTask({ status: "running", completedAt: null, lastActivity: "Working..." });
-    const agent = crossInstanceAgent(task, 1, false);
-    expect(agent.lastActivity).toBe("Working...");
+  test("populates result from prUrl in state file", () => {
+    const agent = liveTaskFromStateFile(
+      makeStateFile({ prUrl: "https://github.com/org/repo/pull/42", finalBranch: "deer/task" }),
+      1,
+    );
+    expect(agent.result?.prUrl).toBe("https://github.com/org/repo/pull/42");
+    expect(agent.result?.finalBranch).toBe("deer/task");
+  });
+});
+
+describe("historicalAgentFromStateFile", () => {
+  test("status is interrupted", () => {
+    const agent = historicalAgentFromStateFile(makeStateFile(), 1);
+    expect(agent.status).toBe("interrupted");
+  });
+
+  test("is marked as historical", () => {
+    const agent = historicalAgentFromStateFile(makeStateFile(), 1);
+    expect(agent.historical).toBe(true);
+  });
+
+  test("has no handle", () => {
+    const agent = historicalAgentFromStateFile(makeStateFile(), 1);
+    expect(agent.handle).toBeNull();
+  });
+
+  test("shows interrupted lastActivity", () => {
+    const agent = historicalAgentFromStateFile(makeStateFile({ lastActivity: "Working..." }), 1);
+    expect(agent.lastActivity).toBe("Interrupted — deer was closed");
+  });
+
+  test("carries over logs from state file", () => {
+    const logs = ["[setup] Creating worktree...", "● Some progress"];
+    const agent = historicalAgentFromStateFile(makeStateFile({ logs }), 1);
+    expect(agent.logs).toEqual(logs);
+  });
+
+  test("preserves elapsed from state file", () => {
+    const agent = historicalAgentFromStateFile(makeStateFile({ elapsed: 99 }), 1);
+    expect(agent.elapsed).toBe(99);
+  });
+
+  test("preserves error from state file", () => {
+    const agent = historicalAgentFromStateFile(makeStateFile({ error: "Claude exited with code 1" }), 1);
+    expect(agent.error).toBe("Claude exited with code 1");
   });
 });

--- a/test/task-state.test.ts
+++ b/test/task-state.test.ts
@@ -1,0 +1,211 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  readTaskState,
+  writeTaskState,
+  removeTaskState,
+  isOwnerAlive,
+  scanLiveTaskIds,
+  type TaskStateFile,
+} from "../src/task-state";
+import * as taskModule from "../src/task";
+
+// Override dataDir for tests by monkey-patching the task-state module's dep
+// We do this by writing state files into a temp tasks dir and pointing the
+// module at it via the real filesystem under a unique temp path.
+
+function makeTempDir(): string {
+  return join(tmpdir(), `deer-task-state-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+function makeStateFile(overrides?: Partial<TaskStateFile>): TaskStateFile {
+  return {
+    taskId: "deer_test01",
+    prompt: "fix the login bug",
+    status: "running",
+    elapsed: 42,
+    lastActivity: "● Implementing fix...",
+    finalBranch: "deer/deer_test01",
+    prUrl: null,
+    error: null,
+    logs: ["[setup] Creating worktree...", "[running] Claude started"],
+    idle: false,
+    createdAt: new Date().toISOString(),
+    ownerPid: process.pid,
+    ...overrides,
+  };
+}
+
+// Temporarily override dataDir to point at a temp directory
+async function withTempDataDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = makeTempDir();
+  await mkdir(join(dir, "tasks"), { recursive: true });
+  const origDataDir = (taskModule as unknown as { dataDir: () => string }).dataDir;
+
+  // We can't easily monkey-patch an ES module, so we test via the filesystem
+  // directly: the task-state functions are pure file I/O against dataDir().
+  // For these tests we'll use the real dataDir but with unique taskIds that
+  // won't collide with real state.
+  return fn(dir);
+}
+
+// Use unique taskIds per test to avoid cross-contamination
+let taskCounter = 0;
+function uniqueTaskId(): string {
+  return `deer_teststate${Date.now()}${taskCounter++}`;
+}
+
+describe("readTaskState", () => {
+  const createdIds: string[] = [];
+
+  afterEach(async () => {
+    for (const id of createdIds) {
+      await removeTaskState(id).catch(() => {});
+    }
+    createdIds.length = 0;
+  });
+
+  test("returns null when no state file exists", async () => {
+    const result = await readTaskState("deer_nonexistent_xyz_abc");
+    expect(result).toBeNull();
+  });
+
+  test("roundtrip: write then read returns the same data", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+    const state = makeStateFile({ taskId });
+
+    await writeTaskState(state);
+    const loaded = await readTaskState(taskId);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.taskId).toBe(taskId);
+    expect(loaded!.prompt).toBe(state.prompt);
+    expect(loaded!.elapsed).toBe(state.elapsed);
+    expect(loaded!.lastActivity).toBe(state.lastActivity);
+    expect(loaded!.logs).toEqual(state.logs);
+    expect(loaded!.idle).toBe(state.idle);
+    expect(loaded!.ownerPid).toBe(state.ownerPid);
+    expect(loaded!.finalBranch).toBe(state.finalBranch);
+    expect(loaded!.prUrl).toBe(state.prUrl);
+  });
+
+  test("write is idempotent — second write overwrites first", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+
+    await writeTaskState(makeStateFile({ taskId, elapsed: 10 }));
+    await writeTaskState(makeStateFile({ taskId, elapsed: 99, lastActivity: "updated" }));
+
+    const loaded = await readTaskState(taskId);
+    expect(loaded!.elapsed).toBe(99);
+    expect(loaded!.lastActivity).toBe("updated");
+  });
+
+  test("persists idle flag", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+    await writeTaskState(makeStateFile({ taskId, idle: true }));
+    const loaded = await readTaskState(taskId);
+    expect(loaded!.idle).toBe(true);
+  });
+
+  test("persists prUrl and finalBranch", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+    const state = makeStateFile({
+      taskId,
+      prUrl: "https://github.com/org/repo/pull/42",
+      finalBranch: "deer/deer_test01",
+    });
+    await writeTaskState(state);
+    const loaded = await readTaskState(taskId);
+    expect(loaded!.prUrl).toBe("https://github.com/org/repo/pull/42");
+    expect(loaded!.finalBranch).toBe("deer/deer_test01");
+  });
+
+  test("persists error field", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+    await writeTaskState(makeStateFile({ taskId, status: "failed", error: "Claude exited with code 1" }));
+    const loaded = await readTaskState(taskId);
+    expect(loaded!.error).toBe("Claude exited with code 1");
+  });
+});
+
+describe("removeTaskState", () => {
+  test("removes an existing state file", async () => {
+    const taskId = uniqueTaskId();
+    await writeTaskState(makeStateFile({ taskId }));
+    expect(await readTaskState(taskId)).not.toBeNull();
+
+    await removeTaskState(taskId);
+    expect(await readTaskState(taskId)).toBeNull();
+  });
+
+  test("is a no-op when no state file exists", async () => {
+    await expect(removeTaskState("deer_neverexisted_xyz")).resolves.toBeUndefined();
+  });
+});
+
+describe("isOwnerAlive", () => {
+  test("returns true for the current process PID", () => {
+    expect(isOwnerAlive(process.pid)).toBe(true);
+  });
+
+  test("returns false for PID 0", () => {
+    // PID 0 is the swapper/idle process — not a valid user process to signal
+    expect(isOwnerAlive(0)).toBe(false);
+  });
+
+  test("returns false for a very large PID that does not exist", () => {
+    // PID 4194304 is beyond the Linux default max_pid (typically 4194304 is the max,
+    // but 99999999 is safely beyond any real process)
+    expect(isOwnerAlive(99999999)).toBe(false);
+  });
+});
+
+describe("scanLiveTaskIds", () => {
+  const createdIds: string[] = [];
+
+  afterEach(async () => {
+    for (const id of createdIds) {
+      await removeTaskState(id).catch(() => {});
+    }
+    createdIds.length = 0;
+  });
+
+  test("returns empty array when no state files exist (or tasks dir missing)", async () => {
+    // This tests against the real dataDir; as long as no state files are
+    // present for the unique IDs we'd create, this is stable.
+    const results = await scanLiveTaskIds();
+    // Result is an array (may be non-empty if other tests left files, but type is correct)
+    expect(Array.isArray(results)).toBe(true);
+  });
+
+  test("includes taskIds for which state files have been written", async () => {
+    const taskId1 = uniqueTaskId();
+    const taskId2 = uniqueTaskId();
+    createdIds.push(taskId1, taskId2);
+
+    await writeTaskState(makeStateFile({ taskId: taskId1 }));
+    await writeTaskState(makeStateFile({ taskId: taskId2 }));
+
+    const results = await scanLiveTaskIds();
+    expect(results).toContain(taskId1);
+    expect(results).toContain(taskId2);
+  });
+
+  test("does not include taskIds whose state files were removed", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+
+    await writeTaskState(makeStateFile({ taskId }));
+    await removeTaskState(taskId);
+
+    const results = await scanLiveTaskIds();
+    expect(results).not.toContain(taskId);
+  });
+});


### PR DESCRIPTION
## Summary

When running multiple deer instances side-by-side or relaunching deer, task state was not seamlessly shared between instances. The previous approach polled tmux panes and read from the JSONL history file, which meant cross-instance tasks showed stale activity, missing logs, and incorrect idle status.

This PR replaces that mechanism with a live `state.json` file per task written by the owning instance. Other instances watch the tasks directory via `fs.watch` (with a 10s safety-net poll) and read the full task state — including logs, idle flag, elapsed time, and last activity — directly from the file. When an owning process dies, the task is shown as interrupted using its last known state.

## Changes

- **`src/task-state.ts`**: New `writeTaskState`/`readTaskState`/`removeTaskState`/`scanLiveTaskIds`/`isOwnerAlive` helpers; `TaskStateFile` type includes `logs`, `idle`, `elapsed`, `ownerPid`, etc.
- **`src/agent-state.ts`**: Replaced `crossInstanceAgent()` with `liveTaskFromStateFile()` (full fidelity from state file) and added `historicalAgentFromStateFile()` for dead-owner interrupted tasks.
- **`src/hooks/useAgentActions.ts`**: Writes `state.json` on timer tick, on activity change, on idle transitions, and removes it in the `finally` block when a task ends. Inlined pane idle tracking (removed `pane-idle` helpers and `paneStateRef`).
- **`src/hooks/useAgentSync.ts`**: Replaced tmux-pane polling for cross-instance tasks with `fs.watch` on the tasks directory + debounced re-sync; reads live state files as the source of truth.
- **`src/components/PromptInput.tsx`**: Explicitly request/pop Kitty keyboard protocol (`\x1b[>1u` / `\x1b[<u`) to reliably distinguish Shift+Enter from Enter.
- **`src/dashboard.tsx`**: Moved confirmation banners into the status bar area.
- **`src/git/finalize.ts`**: Removed unnecessary `cwd: "/tmp"` override.

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.