### PR TITLE
🦌 Refactor AgentState: move runtime handles out of shared state

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -1,9 +1,6 @@
-import { join } from "node:path";
-import { dataDir } from "./task";
 import type { PersistedTask } from "./task";
 import type { TaskStateFile } from "./task-state";
 import type { AgentStatus } from "./state-machine";
-import type { AgentHandle } from "./agent";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -13,8 +10,7 @@ interface TeardownResult {
 }
 
 export interface AgentState {
-  id: number;
-  /** Persistent task ID (deer_xxx format) for history storage */
+  /** Persistent task ID (deer_xxx format) for history storage and React key */
   taskId: string;
   prompt: string;
   /** @example "main" */
@@ -26,14 +22,10 @@ export interface AgentState {
   lastActivity: string;
   /** Log lines (capped) */
   logs: string[];
-  /** Agent handle from the sandbox module */
-  handle: AgentHandle | null;
   /** Teardown result */
   result: TeardownResult | null;
   /** Error message on failure */
   error: string;
-  /** Timer handle */
-  timer: ReturnType<typeof setInterval> | null;
   /** PR state on GitHub */
   prState: "open" | "merged" | "closed" | null;
   /** True if this agent was loaded from history (not spawned this session) */
@@ -44,10 +36,14 @@ export interface AgentState {
   creatingPr: boolean;
   /** True while an existing PR is being updated (new commits pushed) */
   updatingPr: boolean;
-  /** AbortController for cancelling the wait loop */
-  abortController: AbortController | null;
   /** True if this task has been explicitly deleted (suppresses history write on cleanup) */
   deleted: boolean;
+  /** ISO 8601 timestamp when the task was created */
+  createdAt: string;
+  /** Path to the git worktree for this task */
+  worktreePath: string;
+  /** Git branch name for this task */
+  branch: string;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -55,7 +51,6 @@ export interface AgentState {
 /** Factory for AgentState with sensible defaults. */
 export function createAgentState(overrides: Partial<AgentState>): AgentState {
   return {
-    id: 0,
     taskId: "",
     prompt: "",
     baseBranch: "main",
@@ -63,17 +58,17 @@ export function createAgentState(overrides: Partial<AgentState>): AgentState {
     elapsed: 0,
     lastActivity: "",
     logs: [],
-    handle: null,
     result: null,
     error: "",
-    timer: null,
     prState: null,
     historical: false,
     idle: false,
     creatingPr: false,
     updatingPr: false,
-    abortController: null,
     deleted: false,
+    createdAt: new Date().toISOString(),
+    worktreePath: "",
+    branch: "",
     ...overrides,
   };
 }
@@ -81,10 +76,9 @@ export function createAgentState(overrides: Partial<AgentState>): AgentState {
 // ── Historical agent helpers ─────────────────────────────────────────
 
 /** Convert a persisted task to a read-only AgentState for display. */
-export function historicalAgent(task: PersistedTask, id: number): AgentState {
+export function historicalAgent(task: PersistedTask): AgentState {
   const wasInterrupted = task.status === "running";
   return createAgentState({
-    id,
     taskId: task.taskId,
     prompt: task.prompt,
     status: wasInterrupted ? "interrupted" : (task.status as AgentStatus),
@@ -93,6 +87,8 @@ export function historicalAgent(task: PersistedTask, id: number): AgentState {
     result: task.prUrl ? { finalBranch: task.finalBranch ?? "", prUrl: task.prUrl } : null,
     error: task.error || "",
     historical: true,
+    createdAt: task.createdAt,
+    branch: task.finalBranch ?? `deer/${task.taskId}`,
   });
 }
 
@@ -101,11 +97,8 @@ export function historicalAgent(task: PersistedTask, id: number): AgentState {
  * another deer instance. Includes full logs, idle status, and elapsed
  * as written by the owning instance.
  */
-export function liveTaskFromStateFile(stateFile: TaskStateFile, id: number): AgentState {
-  const sessionName = `deer-${stateFile.taskId}`;
-  const worktreePath = join(dataDir(), "tasks", stateFile.taskId, "worktree");
+export function liveTaskFromStateFile(stateFile: TaskStateFile): AgentState {
   return createAgentState({
-    id,
     taskId: stateFile.taskId,
     prompt: stateFile.prompt,
     status: "running",
@@ -117,18 +110,9 @@ export function liveTaskFromStateFile(stateFile: TaskStateFile, id: number): Age
     result: stateFile.prUrl
       ? { finalBranch: stateFile.finalBranch ?? "", prUrl: stateFile.prUrl }
       : null,
-    handle: {
-      taskId: stateFile.taskId,
-      sessionName,
-      worktreePath,
-      branch: stateFile.finalBranch ?? `deer/${stateFile.taskId}`,
-      async kill() {
-        await Bun.spawn(
-          ["tmux", "kill-session", "-t", sessionName],
-          { stdout: "pipe", stderr: "pipe" },
-        ).exited;
-      },
-    },
+    createdAt: stateFile.createdAt,
+    worktreePath: stateFile.worktreePath,
+    branch: stateFile.finalBranch ?? `deer/${stateFile.taskId}`,
   });
 }
 
@@ -136,9 +120,8 @@ export function liveTaskFromStateFile(stateFile: TaskStateFile, id: number): Age
  * Build an AgentState from a state file whose owning process has died.
  * Shows the task as interrupted with its last known state.
  */
-export function historicalAgentFromStateFile(stateFile: TaskStateFile, id: number): AgentState {
+export function historicalAgentFromStateFile(stateFile: TaskStateFile): AgentState {
   return createAgentState({
-    id,
     taskId: stateFile.taskId,
     prompt: stateFile.prompt,
     status: "interrupted",
@@ -150,5 +133,8 @@ export function historicalAgentFromStateFile(stateFile: TaskStateFile, id: numbe
       : null,
     error: stateFile.error || "",
     historical: true,
+    createdAt: stateFile.createdAt,
+    worktreePath: stateFile.worktreePath,
+    branch: stateFile.finalBranch ?? `deer/${stateFile.taskId}`,
   });
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,8 +7,7 @@
 
 import { join, resolve } from "node:path";
 import { createWorktree, removeWorktree } from "./git/worktree";
-import { createPullRequest, cleanupWorktree } from "./git/finalize";
-import type { CreatePRResult } from "./git/finalize";
+import { cleanupWorktree } from "./git/finalize";
 import { launchSandbox, isTmuxSessionDead, captureTmuxPane } from "./sandbox/index";
 import type { SandboxSession, SandboxRuntime } from "./sandbox/index";
 import { generateTaskId, dataDir } from "./task";
@@ -57,6 +56,11 @@ export interface AgentRunOptions {
   runtime: SandboxRuntime;
   /** Callback for status updates */
   onStatus?: (status: AgentStatus) => void;
+  /**
+   * Pre-generated task ID. If not provided, one is generated internally.
+   * Pass this when you need to know the taskId before `startAgent` resolves.
+   */
+  taskId?: string;
   /**
    * If provided, resume an existing Claude conversation instead of starting
    * a fresh one. The worktree and branch are reused; `--continue` is passed
@@ -127,7 +131,7 @@ async function dismissBypassDialog(sessionName: string): Promise<void> {
  * Start an agent: create worktree, launch sandbox, return handle.
  *
  * The agent runs Claude Code interactively in a tmux session.
- * Call `waitForCompletion()` to block until the agent finishes,
+ * Poll `isTmuxSessionDead` to detect when the agent finishes,
  * or use the handle to kill it / attach to it.
  */
 export async function startAgent(options: AgentRunOptions): Promise<AgentHandle> {
@@ -142,7 +146,7 @@ export async function startAgent(options: AgentRunOptions): Promise<AgentHandle>
     continueSession,
   } = options;
 
-  const taskId = continueSession?.taskId ?? generateTaskId();
+  const taskId = options.taskId ?? continueSession?.taskId ?? generateTaskId();
   const sessionName = `deer-${taskId}`;
 
   let worktreePath: string;
@@ -212,46 +216,6 @@ export async function startAgent(options: AgentRunOptions): Promise<AgentHandle>
 }
 
 /**
- * Poll until the agent's tmux session exits.
- * Resolves when the sandboxed Claude process finishes.
- *
- * @param handle - The agent handle from `startAgent()`
- * @param signal - Optional AbortSignal to cancel polling (e.g. on user kill)
- */
-export async function waitForCompletion(
-  handle: AgentHandle,
-  signal?: AbortSignal,
-): Promise<void> {
-  while (true) {
-    if (signal?.aborted) return;
-
-    const dead = await isTmuxSessionDead(handle.sessionName);
-    if (dead) return;
-
-    await Bun.sleep(AGENT_POLL_INTERVAL_MS);
-  }
-}
-
-/**
- * Finalize an agent after it completes: commit, push, create PR.
- */
-export async function createAgentPR(
-  handle: AgentHandle,
-  repoPath: string,
-  baseBranch: string,
-  prompt: string,
-): Promise<CreatePRResult> {
-  return createPullRequest({
-    repoPath,
-    worktreePath: handle.worktreePath,
-    branch: handle.branch,
-    baseBranch,
-    prompt,
-  });
-}
-
-
-/**
  * Get the last N lines of tmux output for an agent.
  */
 export async function getAgentOutput(
@@ -283,22 +247,16 @@ export async function destroyAgent(
 export async function deleteTask(
   taskId: string,
   repoPath: string,
-  handle?: AgentHandle | null,
 ): Promise<void> {
   const worktreePath = join(dataDir(), "tasks", taskId, "worktree");
   const taskDir = join(dataDir(), "tasks", taskId);
-  const branch = handle?.branch ?? `deer/${taskId}`;
+  const branch = `deer/${taskId}`;
 
-  if (handle) {
-    // Kill the tmux session via the handle
-    await handle.kill().catch(() => {});
-  } else {
-    // No handle — kill the tmux session by its conventional name
-    await Bun.spawn(
-      ["tmux", "kill-session", "-t", `deer-${taskId}`],
-      { stdout: "pipe", stderr: "pipe" },
-    ).exited;
-  }
+  // Kill the tmux session by its conventional name
+  await Bun.spawn(
+    ["tmux", "kill-session", "-t", `deer-${taskId}`],
+    { stdout: "pipe", stderr: "pipe" },
+  ).exited;
 
   // Remove the git worktree and branch
   await cleanupWorktree(repoPath, worktreePath, branch);

--- a/src/dashboard-utils.ts
+++ b/src/dashboard-utils.ts
@@ -1,35 +1,6 @@
 import type { AgentStatus } from "./state-machine";
 import type { AgentState } from "./agent-state";
-import {
-  MAX_LOG_LINES,
-  DASHBOARD_POLL_MS,
-  IDLE_THRESHOLD,
-  DEFAULT_MODEL,
-  PR_MERGE_CHECK_INTERVAL_MS,
-  MAX_VISIBLE_LOGS,
-  LOG_LINES_PER_ENTRY,
-  ENTRY_ROWS_BASE,
-  ENTRY_ROWS_WITH_PR,
-  UPLOAD_FRAMES,
-} from "./constants";
-
-// ── Re-exports from constants ───────────────────────────────────────
-// Kept for backwards compatibility with existing imports in dashboard.tsx etc.
-
-export {
-  MAX_LOG_LINES,
-  MAX_VISIBLE_LOGS,
-  LOG_LINES_PER_ENTRY,
-  ENTRY_ROWS_BASE,
-  ENTRY_ROWS_WITH_PR,
-  UPLOAD_FRAMES,
-  PR_MERGE_CHECK_INTERVAL_MS,
-  IDLE_THRESHOLD,
-  DEFAULT_MODEL,
-};
-
-export const MODEL = DEFAULT_MODEL;
-export const POLL_MS = DASHBOARD_POLL_MS;
+import { MAX_LOG_LINES } from "./constants";
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -14,16 +14,18 @@ import { usePromptHistory } from "./hooks/usePromptHistory";
 import { useKeyboardInput } from "./hooks/useKeyboardInput";
 import {
   STATUS_DISPLAY,
-  UPLOAD_FRAMES,
-  MAX_VISIBLE_LOGS,
-  LOG_LINES_PER_ENTRY,
-  ENTRY_ROWS_BASE,
-  ENTRY_ROWS_WITH_PR,
   truncate,
   formatTime,
   isActive,
   prStateColor,
 } from "./dashboard-utils";
+import {
+  UPLOAD_FRAMES,
+  MAX_VISIBLE_LOGS,
+  LOG_LINES_PER_ENTRY,
+  ENTRY_ROWS_BASE,
+  ENTRY_ROWS_WITH_PR,
+} from "./constants";
 
 export { stripAnsi } from "./dashboard-utils";
 
@@ -41,7 +43,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   const guardRef = useRef<ClaudeConfigGuard | null>(null);
   const configRef = useRef<DeerConfig | null>(null);
 
-  const { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory } = useAgentSync(cwd, configRef);
+  const { agents, setAgents, agentsRef, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory } = useAgentSync(cwd, configRef);
 
   const {
     promptHistory,
@@ -56,10 +58,9 @@ export default function Dashboard({ cwd }: { cwd: string }) {
 
   usePrPoller(agentsRef, setAgents);
 
-  const { spawnAgent, killAgent, attachToAgent, openShell, createPr, updatePr, deleteAgent } = useAgentActions({
+  const { spawnAgent, killAgent, abortAllAgents, attachToAgent, openShell, createPr, updatePr, deleteAgent, retryAgent } = useAgentActions({
     cwd,
     setAgents,
-    nextId,
     deletedTaskIdsRef,
     baseBranchRef,
     configRef,
@@ -94,6 +95,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     createPr,
     updatePr,
     deleteAgent,
+    retryAgent,
     exit,
   });
 
@@ -120,11 +122,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     const cleanup = () => {
       // Abort deer's own polling loops so state updates stop, but leave the
       // tmux sessions alive so agents continue running after a restart.
-      for (const agent of agentsRef.current) {
-        if (isActive(agent)) {
-          agent.abortController?.abort();
-        }
-      }
+      abortAllAgents();
       for (const proxyCleanup of restoredProxiesRef.current.values()) {
         proxyCleanup();
       }
@@ -247,7 +245,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
             const logWidth = Math.max(termWidth - 5, 5);
 
             return (
-              <Box key={agent.id} flexDirection="column">
+              <Box key={agent.taskId} flexDirection="column">
                 {/* Title line */}
                 <Box gap={1}>
                   <Box width={2}>
@@ -382,8 +380,8 @@ export default function Dashboard({ cwd }: { cwd: string }) {
                   {selected && availableActions({
                     status: selected.status,
                     hasPrUrl: !!selected.result?.prUrl,
-                    hasFinalBranch: !!selected.result?.finalBranch || !!selected.handle?.branch,
-                    hasHandle: !!selected.handle,
+                    hasFinalBranch: !!selected.result?.finalBranch || !!selected.branch,
+                    hasHandle: selected.status === "running",
                     isIdle: selected.idle,
                     prState: selected.prState,
                     hasWorktreePath: !!selected.taskId,

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -2,15 +2,15 @@ import { useCallback, useRef } from "react";
 import type { MutableRefObject, Dispatch, SetStateAction } from "react";
 import type { AgentState } from "../agent-state";
 import { createAgentState } from "../agent-state";
-import { upsertHistory, removeFromHistory, dataDir } from "../task";
+import { upsertHistory, removeFromHistory, dataDir, generateTaskId } from "../task";
 import type { PersistedTask } from "../task";
 import { writeTaskState, removeTaskState } from "../task-state";
 import type { TaskStateFile } from "../task-state";
 import type { DeerConfig } from "../config";
 import type { PreflightResult } from "../preflight";
-import { startAgent, destroyAgent, deleteTask, createAgentPR } from "../agent";
-import { updatePullRequest } from "../git/finalize";
-import { isTmuxSessionDead, captureTmuxPane } from "../sandbox/index";
+import { startAgent, destroyAgent, deleteTask } from "../agent";
+import { updatePullRequest, createPullRequest } from "../git/finalize";
+import { isTmuxSessionDead, captureTmuxPane, applyTmuxStatusBar } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";
 import { transition } from "../state-machine";
 import { advancePaneState, isIdleState, seedIdleState } from "../pane-idle";
@@ -22,10 +22,19 @@ import {
   captureSnapshot,
   truncate,
   withSuspendedTerminal,
-  MODEL,
-  POLL_MS,
-  IDLE_THRESHOLD,
 } from "../dashboard-utils";
+import {
+  DEFAULT_MODEL,
+  DASHBOARD_POLL_MS,
+  IDLE_THRESHOLD,
+} from "../constants";
+
+// ── Runtime handle map ───────────────────────────────────────────────
+
+interface AgentRuntime {
+  abortController: AbortController;
+  timer: ReturnType<typeof setInterval>;
+}
 
 function toTaskStateFile(agent: AgentState): TaskStateFile {
   return {
@@ -39,8 +48,9 @@ function toTaskStateFile(agent: AgentState): TaskStateFile {
     error: agent.error || null,
     logs: [...agent.logs],
     idle: agent.idle,
-    createdAt: new Date(Date.now() - agent.elapsed * 1000).toISOString(),
+    createdAt: agent.createdAt,
     ownerPid: process.pid,
+    worktreePath: agent.worktreePath,
   };
 }
 
@@ -60,7 +70,7 @@ async function saveToHistory(agent: AgentState, repoPath: string): Promise<void>
     taskId: agent.taskId,
     prompt: agent.prompt,
     status: agent.status as PersistedTask["status"],
-    createdAt: new Date(Date.now() - agent.elapsed * 1000).toISOString(),
+    createdAt: agent.createdAt,
     completedAt: new Date().toISOString(),
     elapsed: agent.elapsed,
     prUrl: agent.result?.prUrl ?? null,
@@ -74,7 +84,6 @@ async function saveToHistory(agent: AgentState, repoPath: string): Promise<void>
 interface AgentActionDeps {
   cwd: string;
   setAgents: Dispatch<SetStateAction<AgentState[]>>;
-  nextId: MutableRefObject<number>;
   deletedTaskIdsRef: MutableRefObject<Set<string>>;
   baseBranchRef: MutableRefObject<string>;
   configRef: MutableRefObject<DeerConfig | null>;
@@ -85,13 +94,15 @@ interface AgentActionDeps {
 export function useAgentActions({
   cwd,
   setAgents,
-  nextId,
   deletedTaskIdsRef,
   baseBranchRef,
   configRef,
   preflight,
   setSuspended,
 }: AgentActionDeps) {
+  /** Per-task runtime handles: abort controller and elapsed timer */
+  const runtimeRef = useRef(new Map<string, AgentRuntime>());
+
   /** Per-task pane snapshot state shared between the poll loop and attachToAgent */
   const paneStateRef = useRef(new Map<string, PaneState>());
 
@@ -102,7 +113,7 @@ export function useAgentActions({
     paneStateRef.current.set(agent.taskId, { snapshot: "", unchangedCount: 0 });
 
     while (true) {
-      await Bun.sleep(POLL_MS);
+      await Bun.sleep(DASHBOARD_POLL_MS);
       if (signal.aborted) return;
 
       const dead = await isTmuxSessionDead(sessionName);
@@ -161,23 +172,24 @@ export function useAgentActions({
     const config = configRef.current;
     if (!config) return;
 
-    const id = nextId.current++;
     const effectiveBranch = baseBranch ?? baseBranchRef.current;
+
+    // Pre-generate the taskId so the agent has a stable React key
+    // during setup before startAgent resolves.
+    const taskId = continueSession?.taskId ?? generateTaskId();
+
     const agent = createAgentState({
-      id,
+      taskId,
       prompt: prompt.trim(),
       baseBranch: effectiveBranch,
+      createdAt: new Date().toISOString(),
+      ...(continueSession && {
+        worktreePath: continueSession.worktreePath,
+        branch: continueSession.branch,
+      }),
     });
 
     const abortController = new AbortController();
-    agent.abortController = abortController;
-
-    // Start elapsed timer — pauses while agent is idle
-    agent.timer = setInterval(() => {
-      if (!agent.idle) agent.elapsed++;
-      if (agent.taskId) persistState(agent);
-      setAgents((prev) => [...prev]);
-    }, 1000);
 
     setAgents((prev) => [...prev, agent]);
 
@@ -192,8 +204,9 @@ export function useAgentActions({
         prompt: prompt.trim(),
         baseBranch: effectiveBranch,
         config,
-        model: MODEL,
+        model: DEFAULT_MODEL,
         runtime: resolveRuntime(config),
+        taskId,
         continueSession,
         onStatus: (status) => {
           const detail = "message" in status ? status.message : status.phase;
@@ -203,8 +216,20 @@ export function useAgentActions({
         },
       });
 
-      agent.handle = handle;
-      agent.taskId = handle.taskId;
+      // Sync worktree/branch from handle (for fresh starts)
+      agent.worktreePath = handle.worktreePath;
+      agent.branch = handle.branch;
+
+      // Start elapsed timer — pauses while agent is idle, persists elapsed every 10s
+      let ticks = 0;
+      const timer = setInterval(() => {
+        if (!agent.idle) agent.elapsed++;
+        ticks++;
+        if (ticks % 10 === 0) persistState(agent);
+        setAgents((prev) => [...prev]);
+      }, 1000);
+
+      runtimeRef.current.set(taskId, { abortController, timer });
       await persistStateAsync(agent);
 
       agent.status = transition(agent.status, "SETUP_COMPLETE") ?? agent.status;
@@ -228,14 +253,17 @@ export function useAgentActions({
         agent.lastActivity = truncate(agent.error, 120);
       }
     } finally {
-      if (agent.timer) clearInterval(agent.timer);
-      agent.timer = null;
-      paneStateRef.current.delete(agent.taskId);
+      const runtime = runtimeRef.current.get(taskId);
+      if (runtime) {
+        clearInterval(runtime.timer);
+        runtimeRef.current.delete(taskId);
+      }
+      paneStateRef.current.delete(taskId);
       if (!agent.deleted) {
         await saveToHistory(agent, cwd);
       }
       // Remove the live state file — the JSONL history entry is now authoritative
-      await removeTaskState(agent.taskId).catch(() => {});
+      await removeTaskState(taskId).catch(() => {});
       setAgents((prev) => [...prev]);
     }
   }, [cwd, preflight]);
@@ -246,40 +274,58 @@ export function useAgentActions({
     if (!isActive(agent)) return;
     agent.status = transition(agent.status, "USER_KILL") ?? "cancelled";
     agent.lastActivity = "Cancelled by user";
-    agent.abortController?.abort();
-    if (agent.handle) {
-      agent.handle.kill().catch(() => {});
+
+    const runtime = runtimeRef.current.get(agent.taskId);
+    if (runtime) {
+      runtime.abortController.abort();
+      clearInterval(runtime.timer);
+      runtimeRef.current.delete(agent.taskId);
     }
-    if (agent.timer) clearInterval(agent.timer);
-    agent.timer = null;
+
+    // Kill the tmux session by its conventional name
+    Bun.spawn(["tmux", "kill-session", "-t", `deer-${agent.taskId}`], {
+      stdout: "pipe", stderr: "pipe",
+    }).exited.catch(() => {});
+
     saveToHistory(agent, cwd);
     persistState(agent);
     setAgents((prev) => [...prev]);
   }, [cwd]);
 
+  // ── Abort all agents (for dashboard shutdown) ─────────────────────
+
+  const abortAllAgents = useCallback(() => {
+    for (const [, runtime] of runtimeRef.current) {
+      runtime.abortController.abort();
+      clearInterval(runtime.timer);
+    }
+    runtimeRef.current.clear();
+  }, []);
+
   // ── Attach to running agent (just tmux attach) ────────────────────
 
   const attachToAgent = useCallback(async (agent: AgentState) => {
-    if (!agent.handle) return;
+    if (!agent.taskId) return;
+    const sessionName = `deer-${agent.taskId}`;
 
     await withSuspendedTerminal(setSuspended, async () => {
       // Small delay to let any pending keypress (e.g. the Enter that triggered
       // attach) flush through before tmux takes over stdin.
       await Bun.sleep(50);
       const { spawnSync } = await import("node:child_process");
-      spawnSync("tmux", ["attach", "-t", agent.handle!.sessionName], {
+      spawnSync("tmux", ["attach", "-t", sessionName], {
         stdio: "inherit",
       });
     });
 
     // After detach, eagerly check whether Claude is still idle rather than
     // waiting for the poll loop to accumulate IDLE_THRESHOLD stable polls.
-    if (agent.handle && agent.status === "running") {
+    if (agent.status === "running") {
       // Let the pane settle after the detach event
-      await Bun.sleep(POLL_MS);
-      const linesA = await captureTmuxPane(agent.handle.sessionName);
-      await Bun.sleep(POLL_MS);
-      const linesB = await captureTmuxPane(agent.handle.sessionName);
+      await Bun.sleep(DASHBOARD_POLL_MS);
+      const linesA = await captureTmuxPane(sessionName);
+      await Bun.sleep(DASHBOARD_POLL_MS);
+      const linesB = await captureTmuxPane(sessionName);
 
       if (linesA && linesB) {
         const snapA = captureSnapshot(linesA);
@@ -312,7 +358,6 @@ export function useAgentActions({
     await withSuspendedTerminal(setSuspended, async () => {
       await Bun.sleep(50);
       const { spawnSync } = await import("node:child_process");
-      const { applyTmuxStatusBar } = await import("../sandbox/index");
       // Create detached session (no-op if already exists); then apply the
       // deer status bar, then attach — so ctrl+b d returns to deer like attach.
       spawnSync("tmux", ["new-session", "-d", "-s", sessionName, "-c", worktreePath, shell]);
@@ -324,19 +369,20 @@ export function useAgentActions({
   // ── Create PR ─────────────────────────────────────────────────────
 
   const createPr = useCallback(async (agent: AgentState) => {
-    if (!agent.handle || agent.result?.prUrl) return;
+    if (!agent.worktreePath || agent.result?.prUrl) return;
 
     agent.creatingPr = true;
     agent.lastActivity = "Creating PR...";
     setAgents((prev) => [...prev]);
 
     try {
-      const result = await createAgentPR(
-        agent.handle,
-        cwd,
-        agent.baseBranch,
-        agent.prompt,
-      );
+      const result = await createPullRequest({
+        repoPath: cwd,
+        worktreePath: agent.worktreePath,
+        branch: agent.branch,
+        baseBranch: agent.baseBranch,
+        prompt: agent.prompt,
+      });
       agent.result = { finalBranch: result.finalBranch, prUrl: result.prUrl };
       agent.lastActivity = "PR created";
     } catch (err) {
@@ -382,9 +428,15 @@ export function useAgentActions({
 
   const deleteAgent = useCallback((agent: AgentState) => {
     agent.deleted = true;
-    agent.abortController?.abort();
-    if (agent.timer) clearInterval(agent.timer);
-    deleteTask(agent.taskId, cwd, agent.handle).catch(() => {});
+
+    const runtime = runtimeRef.current.get(agent.taskId);
+    if (runtime) {
+      runtime.abortController.abort();
+      clearInterval(runtime.timer);
+      runtimeRef.current.delete(agent.taskId);
+    }
+
+    deleteTask(agent.taskId, cwd).catch(() => {});
     setAgents((prev) => prev.filter((a) => a !== agent));
     deletedTaskIdsRef.current.add(agent.taskId);
     removeFromHistory(cwd, agent.taskId).finally(() => {
@@ -392,5 +444,31 @@ export function useAgentActions({
     });
   }, [cwd, setAgents, deletedTaskIdsRef]);
 
-  return { spawnAgent, killAgent, attachToAgent, openShell, createPr, updatePr, deleteAgent };
+  // ── Retry agent ───────────────────────────────────────────────────
+
+  const retryAgent = useCallback((agent: AgentState) => {
+    // Clean up any existing runtime (abort poll loop, clear timer)
+    const runtime = runtimeRef.current.get(agent.taskId);
+    if (runtime) {
+      runtime.abortController.abort();
+      clearInterval(runtime.timer);
+      runtimeRef.current.delete(agent.taskId);
+    }
+
+    const { prompt, baseBranch, worktreePath, branch, taskId } = agent;
+
+    if (worktreePath) {
+      // Kill the tmux session but preserve the worktree for --continue
+      Bun.spawn(["tmux", "kill-session", "-t", `deer-${taskId}`], {
+        stdout: "pipe", stderr: "pipe",
+      }).exited.catch(() => {});
+      setAgents((prev) => prev.filter((a) => a !== agent));
+      spawnAgent(prompt, baseBranch, { taskId, worktreePath, branch });
+    } else {
+      deleteAgent(agent);
+      spawnAgent(prompt, baseBranch);
+    }
+  }, [spawnAgent, deleteAgent, setAgents]);
+
+  return { spawnAgent, killAgent, abortAllAgents, attachToAgent, openShell, createPr, updatePr, deleteAgent, retryAgent };
 }

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -13,7 +13,6 @@ import { TASK_SYNC_DEBOUNCE_MS, TASK_SYNC_SAFETY_POLL_MS } from "../constants";
 
 export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig | null>) {
   const [agents, setAgents] = useState<AgentState[]>([]);
-  const nextId = useRef(1);
   const agentsRef = useRef(agents);
   agentsRef.current = agents;
   const deletedTaskIdsRef = useRef(new Set<string>());
@@ -32,15 +31,18 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
   // ── Sync state from state files + history ──────────────────────────
 
   const syncWithHistory = useCallback(async () => {
-    // Live tasks: read state.json files written by owning deer instances
+    // Live tasks: read all state.json files in parallel
     const liveTaskIds = await scanLiveTaskIds();
-    const liveStateFiles = new Map<string, Awaited<ReturnType<typeof readTaskState>>>();
-    for (const taskId of liveTaskIds) {
-      if (!deletedTaskIdsRef.current.has(taskId)) {
-        const state = await readTaskState(taskId);
-        if (state) liveStateFiles.set(taskId, state);
-      }
-    }
+    const liveStateResults = await Promise.all(
+      liveTaskIds
+        .filter(id => !deletedTaskIdsRef.current.has(id))
+        .map(async id => ({ id, state: await readTaskState(id) })),
+    );
+    const liveStateFiles = new Map(
+      liveStateResults
+        .filter((r): r is { id: string; state: NonNullable<typeof r.state> } => r.state !== null)
+        .map(r => [r.id, r.state]),
+    );
 
     // Completed tasks: JSONL history (only non-running entries now that live tasks
     // use state.json; running entries are kept as a fallback for tasks started by
@@ -68,7 +70,6 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
         continue;
       }
 
-      const id = existing?.id ?? nextId.current++;
       const stateFile = liveStateFiles.get(taskId);
 
       if (stateFile) {
@@ -82,7 +83,7 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
             const cleanup = await runtime.restoreProxy?.(worktreePath, configRef.current.network.allowlist);
             if (cleanup) restoredProxiesRef.current.set(taskId, cleanup);
           }
-          newAgents.push(liveTaskFromStateFile(stateFile, id));
+          newAgents.push(liveTaskFromStateFile(stateFile));
           continue;
         }
 
@@ -92,14 +93,14 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
           proxyCleanup();
           restoredProxiesRef.current.delete(taskId);
         }
-        newAgents.push(historicalAgentFromStateFile(stateFile, id));
+        newAgents.push(historicalAgentFromStateFile(stateFile));
         continue;
       }
 
       // No state.json — fall back to JSONL history entry
       const fileTask = fileTasks.find(t => t.taskId === taskId);
       if (fileTask) {
-        newAgents.push(historicalAgent(fileTask, id));
+        newAgents.push(historicalAgent(fileTask));
       }
     }
 
@@ -162,5 +163,5 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
     };
   }, [syncWithHistory]);
 
-  return { agents, setAgents, agentsRef, nextId, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory };
+  return { agents, setAgents, agentsRef, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, syncWithHistory };
 }

--- a/src/hooks/useKeyboardInput.ts
+++ b/src/hooks/useKeyboardInput.ts
@@ -23,6 +23,7 @@ interface KeyboardInputDeps {
   createPr: (agent: AgentState) => Promise<void>;
   updatePr: (agent: AgentState) => Promise<void>;
   deleteAgent: (agent: AgentState) => void;
+  retryAgent: (agent: AgentState) => void;
   exit: () => void;
 }
 
@@ -43,6 +44,7 @@ export function useKeyboardInput({
   createPr,
   updatePr,
   deleteAgent,
+  retryAgent,
   exit,
 }: KeyboardInputDeps) {
   const [selectedIdx, setSelectedIdx] = useState(0);
@@ -189,8 +191,8 @@ export function useKeyboardInput({
       const ctx = {
         status: agent.status,
         hasPrUrl: !!agent.result?.prUrl,
-        hasFinalBranch: !!agent.result?.finalBranch || !!agent.handle?.branch,
-        hasHandle: !!agent.handle,
+        hasFinalBranch: !!agent.result?.finalBranch || !!agent.branch,
+        hasHandle: agent.status === "running",
         isIdle: agent.idle,
         prState: agent.prState,
         hasWorktreePath: !!agent.taskId,
@@ -233,29 +235,10 @@ export function useKeyboardInput({
       case "toggle_logs":
         setLogExpanded((prev) => !prev);
         break;
-      case "retry": {
-        const retryPrompt = agent.prompt;
-        const retryHandle = agent.handle;
-        agent.abortController?.abort();
-        if (agent.timer) clearInterval(agent.timer);
+      case "retry":
         setSelectedIdx((prev) => Math.min(prev, Math.max(agents.length - 2, 0)));
-
-        if (retryHandle) {
-          // Kill the tmux session but preserve the worktree so Claude can
-          // continue the same conversation with --continue.
-          retryHandle.kill().catch(() => {});
-          setAgents((prev) => prev.filter((a) => a !== agent));
-          spawnAgent(retryPrompt, agent.baseBranch, {
-            taskId: retryHandle.taskId,
-            worktreePath: retryHandle.worktreePath,
-            branch: retryHandle.branch,
-          });
-        } else {
-          deleteAgent(agent);
-          spawnAgent(retryPrompt, agent.baseBranch);
-        }
+        retryAgent(agent);
         break;
-      }
       case "open_shell":
         openShell(agent);
         break;

--- a/src/hooks/useLivePRState.ts
+++ b/src/hooks/useLivePRState.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { MutableRefObject, Dispatch, SetStateAction } from "react";
 import type { AgentState } from "../agent-state";
 import { checkPrState } from "../github";
-import { PR_MERGE_CHECK_INTERVAL_MS } from "../dashboard-utils";
+import { PR_MERGE_CHECK_INTERVAL_MS } from "../constants";
 
 export function usePrPoller(
   agentsRef: MutableRefObject<AgentState[]>,

--- a/src/pane-idle.ts
+++ b/src/pane-idle.ts
@@ -1,4 +1,4 @@
-import { IDLE_THRESHOLD } from "./dashboard-utils";
+import { IDLE_THRESHOLD } from "./constants";
 
 export interface PaneState {
   snapshot: string;

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { dataDir } from "./task";
 import type { TaskMetadata } from "./task";
@@ -20,6 +20,8 @@ export interface TaskStateFile extends TaskMetadata {
   createdAt: string;
   /** PID of the deer process that owns this task */
   ownerPid: number;
+  /** Path to the git worktree for this task */
+  worktreePath: string;
 }
 
 // ── Paths ─────────────────────────────────────────────────────────────
@@ -63,9 +65,8 @@ export async function writeTaskState(state: TaskStateFile): Promise<void> {
  * Called when a task completes, fails, or is deleted.
  */
 export async function removeTaskState(taskId: string): Promise<void> {
-  const path = taskStatePath(taskId);
   try {
-    await Bun.$`rm -f ${path}`.quiet();
+    await unlink(taskStatePath(taskId));
   } catch {
     // Ignore — file may already be gone
   }

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, afterEach, setDefaultTimeout } from "bun:test";
 
 setDefaultTimeout(30_000);
-import { startAgent, waitForCompletion, getAgentOutput, destroyAgent, deleteTask } from "../src/agent";
+import { startAgent, getAgentOutput, destroyAgent, deleteTask } from "../src/agent";
 import type { AgentHandle, AgentStatus } from "../src/agent";
 import { dataDir } from "../src/task";
 import { DEFAULT_CONFIG } from "../src/config";
@@ -71,32 +71,22 @@ describe("agent lifecycle", () => {
     expect(statuses[0].phase).toBe("setup");
   });
 
-  test("waitForCompletion resolves when the session is killed", async () => {
+  test("startAgent respects a pre-generated taskId", async () => {
     const repo = await createTestRepo();
     repos.push(repo);
 
+    const preTaskId = "deer_pretestid0abc";
     const handle = await startAgent({
       repoPath: repo,
-      prompt: "test",
+      prompt: "echo hello",
       baseBranch: "main",
       config: testConfig,
       runtime: nonoRuntime,
+      taskId: preTaskId,
     });
     handles.push(handle);
 
-    // Kill the session after a short delay to trigger completion
-    setTimeout(() => handle.kill(), 1_000);
-
-    const timeout = new Promise<"timeout">((resolve) =>
-      setTimeout(() => resolve("timeout"), 25_000),
-    );
-
-    const result = await Promise.race([
-      waitForCompletion(handle).then(() => "completed" as const),
-      timeout,
-    ]);
-
-    expect(result).toBe("completed");
+    expect(handle.taskId).toBe(preTaskId);
   });
 
   test("getAgentOutput returns tmux pane content", async () => {
@@ -148,7 +138,7 @@ describe("agent lifecycle", () => {
     expect(exists).toBe(false);
   });
 
-  test("deleteTask with handle kills session, removes worktree and task directory", async () => {
+  test("deleteTask kills session, removes worktree and task directory", async () => {
     const repo = await createTestRepo();
     repos.push(repo);
 
@@ -160,7 +150,7 @@ describe("agent lifecycle", () => {
       runtime: nonoRuntime,
     });
 
-    await deleteTask(handle.taskId, repo, handle);
+    await deleteTask(handle.taskId, repo);
 
     // tmux session should be gone
     const proc = Bun.spawn(["tmux", "has-session", "-t", handle.sessionName], {
@@ -178,65 +168,6 @@ describe("agent lifecycle", () => {
     let dirExists = false;
     try { statSync(taskDir); dirExists = true; } catch { /* gone */ }
     expect(dirExists).toBe(false);
-  });
-
-  test("deleteTask without handle kills session, removes worktree and task directory", async () => {
-    const repo = await createTestRepo();
-    repos.push(repo);
-
-    const handle = await startAgent({
-      repoPath: repo,
-      prompt: "test",
-      baseBranch: "main",
-      config: testConfig,
-      runtime: nonoRuntime,
-    });
-
-    // Simulate the "no handle" case — deleteTask should still clean everything up
-    await deleteTask(handle.taskId, repo, null);
-
-    // tmux session should be gone
-    const proc = Bun.spawn(["tmux", "has-session", "-t", handle.sessionName], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(await proc.exited).not.toBe(0);
-
-    // Worktree should be removed
-    expect(await Bun.file(join(handle.worktreePath, "README.md")).exists()).toBe(false);
-
-    // Task directory should be removed
-    const taskDir = join(dataDir(), "tasks", handle.taskId);
-    const { statSync } = await import("node:fs");
-    let dirExists = false;
-    try { statSync(taskDir); dirExists = true; } catch { /* gone */ }
-    expect(dirExists).toBe(false);
-  });
-
-  test("waitForCompletion respects AbortSignal", async () => {
-    const repo = await createTestRepo();
-    repos.push(repo);
-
-    const handle = await startAgent({
-      repoPath: repo,
-      prompt: "sleep 60",
-      baseBranch: "main",
-      config: testConfig,
-      runtime: nonoRuntime,
-    });
-    handles.push(handle);
-
-    const controller = new AbortController();
-
-    // Abort after 200ms
-    setTimeout(() => controller.abort(), 200);
-
-    const start = Date.now();
-    await waitForCompletion(handle, controller.signal);
-    const elapsed = Date.now() - start;
-
-    // Should have returned quickly, not waited the full poll interval
-    expect(elapsed).toBeLessThan(5_000);
   });
 
   test("startAgent with continueSession reuses existing worktree and taskId", async () => {

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -58,47 +58,48 @@ describe("fuzzyMatch", () => {
 describe("historicalAgent", () => {
   test("converts running status to interrupted", () => {
     const task = makeTask({ status: "running", completedAt: null });
-    const agent = historicalAgent(task, 1);
+    const agent = historicalAgent(task);
     expect(agent.status).toBe("interrupted");
     expect(agent.lastActivity).toBe("Interrupted — deer was closed");
   });
 
   test("preserves cancelled status", () => {
     const task = makeTask({ status: "cancelled" });
-    const agent = historicalAgent(task, 1);
+    const agent = historicalAgent(task);
     expect(agent.status).toBe("cancelled");
   });
 
   test("preserves failed status with error", () => {
     const task = makeTask({ status: "failed", error: "Claude exited with code 1", prUrl: null });
-    const agent = historicalAgent(task, 1);
+    const agent = historicalAgent(task);
     expect(agent.status).toBe("failed");
     expect(agent.error).toBe("Claude exited with code 1");
   });
 
-  test("preserves cancelled status", () => {
-    const task = makeTask({ status: "cancelled" });
-    const agent = historicalAgent(task, 1);
-    expect(agent.status).toBe("cancelled");
-  });
-
   test("is marked as historical", () => {
     const task = makeTask();
-    const agent = historicalAgent(task, 1);
+    const agent = historicalAgent(task);
     expect(agent.historical).toBe(true);
   });
 
   test("populates result from prUrl", () => {
     const task = makeTask({ prUrl: "https://github.com/org/repo/pull/1", finalBranch: "deer/my-task" });
-    const agent = historicalAgent(task, 1);
+    const agent = historicalAgent(task);
     expect(agent.result?.prUrl).toBe("https://github.com/org/repo/pull/1");
     expect(agent.result?.finalBranch).toBe("deer/my-task");
   });
 
-  test("has no handle", () => {
+  test("has no worktreePath (historical tasks are not live)", () => {
     const task = makeTask();
-    const agent = historicalAgent(task, 1);
-    expect(agent.handle).toBeNull();
+    const agent = historicalAgent(task);
+    expect(agent.worktreePath).toBe("");
+  });
+
+  test("preserves createdAt from task", () => {
+    const createdAt = "2024-01-15T10:00:00.000Z";
+    const task = makeTask({ createdAt });
+    const agent = historicalAgent(task);
+    expect(agent.createdAt).toBe(createdAt);
   });
 });
 
@@ -116,64 +117,63 @@ function makeStateFile(overrides?: Partial<TaskStateFile>): TaskStateFile {
     idle: false,
     createdAt: new Date().toISOString(),
     ownerPid: process.pid,
+    worktreePath: "/home/user/.local/share/deer/tasks/deer_xxx/worktree",
     ...overrides,
   };
 }
 
 describe("liveTaskFromStateFile", () => {
   test("status is running", () => {
-    const agent = liveTaskFromStateFile(makeStateFile(), 1);
+    const agent = liveTaskFromStateFile(makeStateFile());
     expect(agent.status).toBe("running");
   });
 
   test("is marked as historical", () => {
-    const agent = liveTaskFromStateFile(makeStateFile(), 1);
+    const agent = liveTaskFromStateFile(makeStateFile());
     expect(agent.historical).toBe(true);
   });
 
-  test("has a handle with correct sessionName", () => {
+  test("taskId matches state file taskId", () => {
     const taskId = generateTaskId();
-    const agent = liveTaskFromStateFile(makeStateFile({ taskId }), 1);
-    expect(agent.handle).not.toBeNull();
-    expect(agent.handle?.sessionName).toBe(`deer-${taskId}`);
+    const agent = liveTaskFromStateFile(makeStateFile({ taskId }));
+    expect(agent.taskId).toBe(taskId);
   });
 
-  test("handle taskId matches task taskId", () => {
-    const taskId = generateTaskId();
-    const agent = liveTaskFromStateFile(makeStateFile({ taskId }), 1);
-    expect(agent.handle?.taskId).toBe(taskId);
+  test("worktreePath comes from state file", () => {
+    const worktreePath = "/tmp/deer-test/worktree";
+    const agent = liveTaskFromStateFile(makeStateFile({ worktreePath }));
+    expect(agent.worktreePath).toBe(worktreePath);
   });
 
   test("preserves lastActivity from state file", () => {
-    const agent = liveTaskFromStateFile(makeStateFile({ lastActivity: "Fixing bug..." }), 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ lastActivity: "Fixing bug..." }));
     expect(agent.lastActivity).toBe("Fixing bug...");
   });
 
   test("elapsed matches state file elapsed", () => {
-    const agent = liveTaskFromStateFile(makeStateFile({ elapsed: 42 }), 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ elapsed: 42 }));
     expect(agent.elapsed).toBe(42);
   });
 
   test("idle defaults to false", () => {
-    const agent = liveTaskFromStateFile(makeStateFile({ idle: false }), 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ idle: false }));
     expect(agent.idle).toBe(false);
   });
 
   test("idle is set to true when state file has idle=true", () => {
-    const agent = liveTaskFromStateFile(makeStateFile({ idle: true }), 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ idle: true }));
     expect(agent.idle).toBe(true);
   });
 
   test("carries over logs from state file", () => {
     const logs = ["[setup] Creating worktree...", "[running] Claude started", "● Fixing the issue"];
-    const agent = liveTaskFromStateFile(makeStateFile({ logs }), 1);
+    const agent = liveTaskFromStateFile(makeStateFile({ logs }));
     expect(agent.logs).toEqual(logs);
   });
 
   test("populates result from prUrl in state file", () => {
     const agent = liveTaskFromStateFile(
       makeStateFile({ prUrl: "https://github.com/org/repo/pull/42", finalBranch: "deer/task" }),
-      1,
     );
     expect(agent.result?.prUrl).toBe("https://github.com/org/repo/pull/42");
     expect(agent.result?.finalBranch).toBe("deer/task");
@@ -182,38 +182,39 @@ describe("liveTaskFromStateFile", () => {
 
 describe("historicalAgentFromStateFile", () => {
   test("status is interrupted", () => {
-    const agent = historicalAgentFromStateFile(makeStateFile(), 1);
+    const agent = historicalAgentFromStateFile(makeStateFile());
     expect(agent.status).toBe("interrupted");
   });
 
   test("is marked as historical", () => {
-    const agent = historicalAgentFromStateFile(makeStateFile(), 1);
+    const agent = historicalAgentFromStateFile(makeStateFile());
     expect(agent.historical).toBe(true);
   });
 
-  test("has no handle", () => {
-    const agent = historicalAgentFromStateFile(makeStateFile(), 1);
-    expect(agent.handle).toBeNull();
+  test("has worktreePath from state file", () => {
+    const worktreePath = "/tmp/deer-test/worktree";
+    const agent = historicalAgentFromStateFile(makeStateFile({ worktreePath }));
+    expect(agent.worktreePath).toBe(worktreePath);
   });
 
   test("shows interrupted lastActivity", () => {
-    const agent = historicalAgentFromStateFile(makeStateFile({ lastActivity: "Working..." }), 1);
+    const agent = historicalAgentFromStateFile(makeStateFile({ lastActivity: "Working..." }));
     expect(agent.lastActivity).toBe("Interrupted — deer was closed");
   });
 
   test("carries over logs from state file", () => {
     const logs = ["[setup] Creating worktree...", "● Some progress"];
-    const agent = historicalAgentFromStateFile(makeStateFile({ logs }), 1);
+    const agent = historicalAgentFromStateFile(makeStateFile({ logs }));
     expect(agent.logs).toEqual(logs);
   });
 
   test("preserves elapsed from state file", () => {
-    const agent = historicalAgentFromStateFile(makeStateFile({ elapsed: 99 }), 1);
+    const agent = historicalAgentFromStateFile(makeStateFile({ elapsed: 99 }));
     expect(agent.elapsed).toBe(99);
   });
 
   test("preserves error from state file", () => {
-    const agent = historicalAgentFromStateFile(makeStateFile({ error: "Claude exited with code 1" }), 1);
+    const agent = historicalAgentFromStateFile(makeStateFile({ error: "Claude exited with code 1" }));
     expect(agent.error).toBe("Claude exited with code 1");
   });
 });

--- a/test/pane-idle.test.ts
+++ b/test/pane-idle.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from "bun:test";
 import { advancePaneState, isIdleState, seedIdleState } from "../src/pane-idle";
 import type { PaneState } from "../src/pane-idle";
-import { IDLE_THRESHOLD } from "../src/dashboard-utils";
+import { IDLE_THRESHOLD } from "../src/constants";
 
 function emptyState(): PaneState {
   return { snapshot: "", unchangedCount: 0 };

--- a/test/task-state.test.ts
+++ b/test/task-state.test.ts
@@ -34,6 +34,7 @@ function makeStateFile(overrides?: Partial<TaskStateFile>): TaskStateFile {
     idle: false,
     createdAt: new Date().toISOString(),
     ownerPid: process.pid,
+    worktreePath: "/home/user/.local/share/deer/tasks/deer_test01/worktree",
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Arch review revealed that mutable runtime handles (`AbortController`, `setInterval` timer, `AgentHandle`) were stored directly on `AgentState`, which is shared across React renders and persisted to disk. This caused coupling between transient runtime state and serializable task data.

Runtime handles are now stored in a `runtimeRef` map keyed by `taskId` inside `useAgentActions`, keeping `AgentState` pure and serializable. Stable fields like `createdAt`, `worktreePath`, and `branch` are promoted to first-class `AgentState` properties.

## Changes

- Removed `handle`, `timer`, `abortController`, and numeric `id` from `AgentState`
- Added `createdAt`, `worktreePath`, and `branch` as first-class fields on `AgentState`
- Introduced `AgentRuntime` interface (`abortController` + `timer`) stored in `runtimeRef` map in `useAgentActions`
- Pre-generate `taskId` before `startAgent` resolves so React keys are stable during setup
- Removed `waitForCompletion` and `createAgentPR` from `agent.ts` (logic inlined or reorganised)
- Simplified `deleteTask` to always kill tmux session by conventional name (no handle needed)
- Removed re-export shims from `dashboard-utils.ts`; consumers now import directly from `constants`
- React list now keys on `agent.taskId` instead of `agent.id`
- `historicalAgent`, `liveTaskFromStateFile`, `historicalAgentFromStateFile` no longer require a numeric `id` argument

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.