### PR TITLE
🦌 Add CI release pipeline and npm install script for deer binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.1.0)"
+        required: true
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist
+          bun build --compile --target=bun-linux-x64   src/cli.tsx --outfile dist/deer-linux-x64
+          bun build --compile --target=bun-linux-arm64  src/cli.tsx --outfile dist/deer-linux-arm64
+          bun build --compile --target=bun-darwin-x64  src/cli.tsx --outfile dist/deer-darwin-x64
+          bun build --compile --target=bun-darwin-arm64 src/cli.tsx --outfile dist/deer-darwin-arm64
+
+      - name: Verify binaries
+        run: ls -lh dist/
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/deer-*
+          generate_release_notes: true
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,21 @@
 {
-  "name": "deer",
+  "name": "@zdavison/deer",
   "version": "0.1.0",
   "description": "Unattended coding agent.",
   "type": "module",
   "bin": {
-    "deer": "src/cli.tsx"
+    "deer": "scripts/install.js"
+  },
+  "files": [
+    "scripts/install.js"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "test": "bun test",
-    "dev": "bun run src/cli.tsx"
+    "dev": "bun run src/cli.tsx",
+    "build": "bun build --compile --target=bun-linux-x64 src/cli.tsx --outfile dist/deer-linux-x64"
   },
   "dependencies": {
     "@iarna/toml": "^3.0.0",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { writeFile, chmod, mkdir } from "fs/promises";
+import { join, dirname } from "path";
+import { homedir, platform, arch } from "os";
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json");
+
+const REPO = "mm-zacharydavison/deer";
+const VERSION = pkg.version;
+
+const PLATFORM_MAP = {
+  linux: "linux",
+  darwin: "darwin",
+};
+
+const ARCH_MAP = {
+  x64: "x64",
+  arm64: "arm64",
+};
+
+async function install() {
+  const os = PLATFORM_MAP[platform()];
+  const cpuArch = ARCH_MAP[arch()];
+
+  if (!os) {
+    throw new Error(
+      `Unsupported platform: ${platform()}. Supported: linux, darwin.`
+    );
+  }
+  if (!cpuArch) {
+    throw new Error(
+      `Unsupported architecture: ${arch()}. Supported: x64, arm64.`
+    );
+  }
+
+  const binaryName = `deer-${os}-${cpuArch}`;
+  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${binaryName}`;
+  const installDir = join(homedir(), ".local", "bin");
+  const installPath = join(installDir, "deer");
+
+  console.log(`Downloading deer v${VERSION} for ${os}/${cpuArch}...`);
+  console.log(`From: ${url}`);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}\nURL: ${url}`
+    );
+  }
+
+  await mkdir(installDir, { recursive: true });
+
+  const buffer = await response.arrayBuffer();
+  await writeFile(installPath, Buffer.from(buffer));
+  await chmod(installPath, 0o755);
+
+  console.log(`\nInstalled to: ${installPath}`);
+
+  // Warn if installDir is not in PATH
+  const pathDirs = (process.env.PATH ?? "").split(":");
+  if (!pathDirs.includes(installDir)) {
+    console.log(
+      `\nNote: ${installDir} is not in your PATH. Add this to your shell profile:`
+    );
+    console.log(`  export PATH="$HOME/.local/bin:$PATH"`);
+  }
+}
+
+const args = process.argv.slice(2);
+
+if (args[0] === "install") {
+  install().catch((err) => {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  });
+} else {
+  console.log("Usage: bunx @zdavison/deer install");
+  console.log("");
+  console.log("Commands:");
+  console.log("  install    Download and install the deer binary");
+}


### PR DESCRIPTION
## Summary

Prepares deer for distribution as a standalone binary. Adds a GitHub Actions workflow to build and release cross-platform binaries on version tags, an install script that downloads the correct binary from GitHub Releases, and updates `package.json` for npm publishing under `@zdavison/deer`.

## Changes

- Added `.github/workflows/release.yml` to build `deer` binaries for Linux/macOS (x64/arm64) and publish them as GitHub Release assets on `v*` tags or manual dispatch
- Added `scripts/install.js` — the npm bin entry point; running `bunx @zdavison/deer install` downloads and installs the correct platform binary to `~/.local/bin/deer`
- Updated `package.json`: renamed package to `@zdavison/deer`, set `bin` to the install script, added `files` and `publishConfig.access: public` for npm publishing, added a `build` script

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.