### PR TITLE
🦌 Simplify install script to run directly via bunx

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -71,16 +71,7 @@ async function install() {
   }
 }
 
-const args = process.argv.slice(2);
-
-if (args[0] === "install") {
-  install().catch((err) => {
-    console.error(`Error: ${err.message}`);
-    process.exit(1);
-  });
-} else {
-  console.log("Usage: bunx @zdavison/deer install");
-  console.log("");
-  console.log("Commands:");
-  console.log("  install    Download and install the deer binary");
-}
+install().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Previously, the install script required users to pass an explicit `install` subcommand (`bunx @zdavison/deer install`). This change removes the subcommand check so that running `bunx @zdavison/deer` directly triggers the install, matching the expected UX for bunx-style packages.

## Changes

- Removed argument parsing and subcommand dispatch from `scripts/install.js`
- `install()` is now called unconditionally when the script runs
- `bunx @zdavison/deer` now works without any additional arguments

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.