### PR TITLE
🦌 currently, whenever we attach to an agent and go back to the T...

### DIFF
--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -311,6 +311,11 @@ export function useAgentActions({
     if (!agent.taskId) return;
     const sessionName = `deer-${agent.taskId}`;
 
+    // Snapshot the pane before attaching so we can detect whether anything
+    // actually changed while we were in the session.
+    const preAttachLines = await captureTmuxPane(sessionName);
+    const preAttachSnapshot = preAttachLines ? captureSnapshot(preAttachLines) : null;
+
     await withSuspendedTerminal(setSuspended, async () => {
       // Small delay to let any pending keypress (e.g. the Enter that triggered
       // attach) flush through before tmux takes over stdin.
@@ -327,23 +332,36 @@ export function useAgentActions({
       // Let the pane settle after the detach event
       await Bun.sleep(DASHBOARD_POLL_MS);
       const linesA = await captureTmuxPane(sessionName);
-      await Bun.sleep(DASHBOARD_POLL_MS);
-      const linesB = await captureTmuxPane(sessionName);
 
-      if (linesA && linesB) {
+      if (linesA) {
         const snapA = captureSnapshot(linesA);
-        const snapB = captureSnapshot(linesB);
 
-        if (snapA === snapB) {
-          // Pane is stable — seed the poll loop's counter so idle is recognised
-          // on the very next tick, and update the UI immediately.
-          paneStateRef.current.set(agent.taskId, seedIdleState(snapB));
+        if (preAttachSnapshot !== null && snapA === preAttachSnapshot) {
+          // Pane is identical to what it was before we attached — nothing
+          // changed during the session. Restore idle immediately.
+          paneStateRef.current.set(agent.taskId, seedIdleState(snapA));
           agent.idle = true;
-          agent.lastActivity = "Idle — press ⏎ to attach";
+          agent.lastActivity = "Idle \u2014 press \u23CE to attach";
         } else {
-          // Pane is changing — Claude started working; let poll loop handle it.
-          const lastLine = linesB.map(stripAnsi).map((l) => l.trim()).filter(Boolean).pop();
-          if (lastLine) agent.lastActivity = truncate(lastLine, 120);
+          // Content changed. Take a second snapshot to see if it has stabilised.
+          await Bun.sleep(DASHBOARD_POLL_MS);
+          const linesB = await captureTmuxPane(sessionName);
+
+          if (linesB) {
+            const snapB = captureSnapshot(linesB);
+
+            if (snapA === snapB) {
+              // Pane is stable — seed the poll loop's counter so idle is
+              // recognised on the very next tick, and update the UI immediately.
+              paneStateRef.current.set(agent.taskId, seedIdleState(snapB));
+              agent.idle = true;
+              agent.lastActivity = "Idle \u2014 press \u23CE to attach";
+            } else {
+              // Pane is changing — Claude started working; let poll loop handle it.
+              const lastLine = linesB.map(stripAnsi).map((l) => l.trim()).filter(Boolean).pop();
+              if (lastLine) agent.lastActivity = truncate(lastLine, 120);
+            }
+          }
         }
       }
       setAgents((prev) => [...prev]);


### PR DESCRIPTION
## Summary

> currently, whenever we attach to an agent and go back to the TUI menu, even if we made no changes, we still enter "running" state for a moment until idle kicks back in. We should track the pane conten...

### Commits

```
675785a deer: uncommitted changes from agent session
```

---
> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.