### PR TITLE
🦌 Sort TUI agent list oldest to newest for stable ordering

### DIFF
--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -111,6 +111,9 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       }
     }
 
+    // Sort oldest → newest so the list is stable and doesn't jump around
+    newAgents.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
     const changed =
       newAgents.length !== currentAgents.length ||
       newAgents.some((a, i) => {


### PR DESCRIPTION
## Summary

The TUI agent list was jumping around because items had no consistent ordering. This change sorts agents by their `createdAt` timestamp (oldest → newest) so the list remains stable as new agents are added or state updates occur.

## Changes

- Added `.sort()` on `newAgents` by `createdAt` timestamp before comparing against current agents in `useAgentSync`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.