### PR TITLE
🦌 Include original task prompt in PR description

### DIFF
--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -128,8 +128,8 @@ async function generatePRMetadata(worktreePath: string, baseBranch: string, prom
     : "";
 
   const bodyInstruction = prTemplate
-    ? "body: follow the PR template structure above, filling in relevant sections based on the changes. End with a horizontal rule and \"> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.\""
-    : "body: markdown with a ## Summary section describing what changed and why, followed by a ## Changes section with bullet points of key changes. End with a horizontal rule and \"> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.\"";
+    ? "body: follow the PR template structure above, filling in relevant sections based on the changes. Start with a ## Task section containing the original task prompt as a blockquote. End with a horizontal rule and \"> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.\""
+    : "body: markdown starting with a ## Task section containing the original task prompt as a blockquote, followed by a ## Summary section describing what changed and why, then a ## Changes section with bullet points of key changes. End with a horizontal rule and \"> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.\"";
 
   const metadataPrompt = `You are generating metadata for a pull request. Analyze the following task prompt, commits, and diff, then produce EXACTLY the following JSON (no markdown fences, no extra text):
 


### PR DESCRIPTION
## Task

> when we create a PR description, the prompt that deer task was started with should be included in a quote in the PR description

## Summary

PR descriptions generated by deer now include the original task prompt as a blockquote in a `## Task` section at the top. This gives reviewers immediate context about what was being asked before reading the summary and changes.

Also removes an unnecessary sort of agents by `createdAt` in `useAgentSync`.

## Changes

- Updated `generatePRMetadata` body instructions (both template and non-template paths) to prepend a `## Task` section with the original task prompt as a blockquote
- Removed agent sort by `createdAt` in `useAgentSync`

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.