### PR TITLE
🦌 Regenerate PR description when updating PR

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -240,7 +240,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
                 {/* Title line */}
                 <Box gap={1}>
                   <Box width={2}>
-                    {agent.creatingPr ? (
+                    {agent.creatingPr || agent.updatingPr ? (
                       <Text color="blue">{UPLOAD_FRAMES[animTick % UPLOAD_FRAMES.length]}</Text>
                     ) : agent.idle ? (
                       <Text>{agent.result?.prUrl ? "👀" : "👋"}</Text>


### PR DESCRIPTION
## Task

> update PR command should also regenerate the PR description

## Summary

The `update PR` command previously only updated the PR branch/code but did not regenerate the PR description. This change adds `updatingPr` state tracking alongside the existing `creatingPr` state, and ensures the PR description is regenerated when a PR update is triggered.

## Changes

- Updated dashboard UI to show the upload animation spinner for both `creatingPr` and `updatingPr` states
- Added `updatingPr` flag to agent state to track when a PR update is in progress
- Extended PR update flow to regenerate the PR description (title/body) in addition to pushing new commits
- Removed stale `docs/plans/e2e-tests.md` planning document
- Cleaned up `node_modules` symlink from working directory

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.