### PR TITLE
🦌 Add srt dependency and fix install fallbacks for npm/bun

### DIFF
--- a/.kadai/actions/setup.ts
+++ b/.kadai/actions/setup.ts
@@ -120,11 +120,34 @@ const tools: Tool[] = [
     },
   },
   {
+    name: "srt (@anthropic-ai/sandbox-runtime)",
+    check: () => commandExists("srt"),
+    async install() {
+      if (await commandExists("npm")) {
+        log("  Installing srt via npm...");
+        await $`npm install -g @anthropic-ai/sandbox-runtime`;
+      } else if (await commandExists("bun")) {
+        log("  Installing srt via bun...");
+        await $`bun add -g @anthropic-ai/sandbox-runtime`;
+      } else {
+        log("  Could not find npm or bun. Install @anthropic-ai/sandbox-runtime manually.");
+      }
+    },
+    note: "Required by deer for sandboxing (macOS: seatbelt, Linux: bubblewrap)",
+  },
+  {
     name: "claude (Claude Code CLI)",
     check: () => commandExists("claude"),
     async install() {
-      log("  Installing Claude Code via npm...");
-      await $`npm install -g @anthropic-ai/claude-code`;
+      if (await commandExists("npm")) {
+        log("  Installing Claude Code via npm...");
+        await $`npm install -g @anthropic-ai/claude-code`;
+      } else if (await commandExists("bun")) {
+        log("  Installing Claude Code via bun...");
+        await $`bun add -g @anthropic-ai/claude-code`;
+      } else {
+        log("  Could not find npm or bun. Install @anthropic-ai/claude-code manually.");
+      }
     },
   },
   {


### PR DESCRIPTION
## Task

> check the install action and verify that it installs all required dependencies if not already installed, also check the "setup development environment" kadai action

## Summary

Audited the setup action and found two gaps: the `@anthropic-ai/sandbox-runtime` (`srt`) CLI tool was missing from the dependency list entirely, and the Claude Code install step assumed `npm` was always available without a fallback.

Both issues are now fixed: `srt` is added as a required tool with a note explaining its purpose, and both `srt` and `claude` installation steps now fall back to `bun` if `npm` is not found, or print a manual install message if neither is available.

## Changes

- `.kadai/actions/setup.ts`: Added `srt` (`@anthropic-ai/sandbox-runtime`) as a required tool with npm/bun install logic and a descriptive note
- `.kadai/actions/setup.ts`: Updated `claude` install step to fall back to `bun` if `npm` is unavailable, with a final fallback message for manual installation

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.