### PR TITLE
🦌 Fix process not exiting cleanly after detach message

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -129,6 +129,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
     process.on("SIGTERM", () => { cleanup(); process.exit(0); });
 
     return () => {
+      cleanup();
       process.removeListener("exit", cleanup);
     };
   }, [cwd]);


### PR DESCRIPTION
## Task

> when we close deer, we have to CTRL+C after we get the "detached" message, ideally we shouldnt have to

## Summary

When the dashboard component unmounted (e.g. on close), the cleanup function was registered for signal events but was never called on unmount itself. This left the process in a hanging state after the "detached" message, requiring a manual CTRL+C to exit.

The fix calls `cleanup()` directly in the React effect's teardown function so that resources are released immediately when the component unmounts, allowing the process to exit on its own.

## Changes

- `src/dashboard.tsx`: Call `cleanup()` in the effect's return function so it runs on component unmount, not just on process signals.

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.