### PR TITLE
🦌 Show cost column for pay-as-you-go API token users

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -49,6 +49,8 @@ export interface AgentState {
   worktreePath: string;
   /** Git branch name for this task */
   branch: string;
+  /** Cumulative API cost in USD (only set when using pay-as-you-go API key) */
+  cost: number | null;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -74,6 +76,7 @@ export function createAgentState(overrides: Partial<AgentState>): AgentState {
     createdAt: new Date().toISOString(),
     worktreePath: "",
     branch: "",
+    cost: null,
     ...overrides,
   };
 }
@@ -98,6 +101,7 @@ export function historicalAgent(task: PersistedTask): AgentState {
     createdAt: task.createdAt,
     worktreePath: task.worktreePath || "",
     branch: task.finalBranch ?? `deer/${task.taskId}`,
+    cost: task.cost ?? null,
   });
 }
 
@@ -123,6 +127,7 @@ export function liveTaskFromStateFile(stateFile: TaskStateFile): AgentState {
     createdAt: stateFile.createdAt,
     worktreePath: stateFile.worktreePath,
     branch: stateFile.finalBranch ?? `deer/${stateFile.taskId}`,
+    cost: stateFile.cost ?? null,
   });
 }
 
@@ -153,5 +158,6 @@ export function historicalAgentFromStateFile(stateFile: TaskStateFile): AgentSta
     createdAt: stateFile.createdAt,
     worktreePath: stateFile.worktreePath,
     branch: stateFile.finalBranch ?? `deer/${stateFile.taskId}`,
+    cost: stateFile.cost ?? null,
   });
 }

--- a/src/dashboard-utils.ts
+++ b/src/dashboard-utils.ts
@@ -27,6 +27,31 @@ export function formatTime(seconds: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
+export function formatCost(cost: number): string {
+  if (cost < 0.01) return "<$0.01";
+  return `$${cost.toFixed(2)}`;
+}
+
+/**
+ * Scan tmux pane lines for a Claude Code cost output like "Cost: $0.0234".
+ * Returns the last dollar amount found in a cost-bearing line, or null.
+ */
+export function parseCostFromPane(lines: string[]): number | null {
+  let lastCost: number | null = null;
+  for (const line of lines) {
+    const cleaned = stripAnsi(line).trim();
+    // Prefer lines explicitly mentioning cost
+    if (/cost/i.test(cleaned)) {
+      const match = cleaned.match(/\$(\d+\.\d+)/);
+      if (match) {
+        const val = parseFloat(match[1]);
+        if (!isNaN(val)) lastCost = val;
+      }
+    }
+  }
+  return lastCost;
+}
+
 export function appendLog(agent: AgentState, line: string, verbose = false) {
   agent.logs.push({ text: line, verbose });
   if (agent.logs.length > MAX_LOG_LINES) {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -16,6 +16,7 @@ import {
   STATUS_DISPLAY,
   truncate,
   formatTime,
+  formatCost,
   isActive,
   prStateColor,
 } from "./dashboard-utils";
@@ -171,6 +172,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   const hasPrEntries = agents.some((a) => a.result?.prUrl);
   const entryRows = hasPrEntries ? ENTRY_ROWS_WITH_PR : ENTRY_ROWS_BASE;
   const maxVisibleEntries = Math.max(Math.floor(listHeight / entryRows), 1);
+  const isApiToken = preflight?.credentialType === "api-token";
 
   // ── Render ────────────────────────────────────────────────────────
 
@@ -225,13 +227,14 @@ export default function Dashboard({ cwd }: { cwd: string }) {
             );
             const filteredLogs = verboseMode ? normalizedLogs : normalizedLogs.filter((l) => !l.verbose);
             const recentLogs = filteredLogs.slice(-LOG_LINES_PER_ENTRY);
-            const titleOverhead = 11;
             const prBadge = agent.result?.prUrl && agent.prState
               ? {
                   icon: agent.prState === "merged" ? "🟣" : agent.prState === "closed" ? "🔴" : "🟢",
                   color: prStateColor(agent.prState),
                 }
               : null;
+            const costStr = isApiToken && agent.cost != null ? formatCost(agent.cost) : null;
+            const titleOverhead = 11 + (costStr ? costStr.length + 1 : 0);
             const titleWidth = Math.max(termWidth - titleOverhead - (prBadge ? 3 : 0), 5);
             const logWidth = Math.max(termWidth - 5, 5);
 
@@ -258,6 +261,7 @@ export default function Dashboard({ cwd }: { cwd: string }) {
                   </Box>
                   {prBadge && <Text>{prBadge.icon}</Text>}
                   <Text dimColor>{formatTime(agent.elapsed)}</Text>
+                  {costStr && <Text dimColor>{costStr}</Text>}
                 </Box>
                 {/* PR link line */}
                 {agent.result?.prUrl && (

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -22,6 +22,7 @@ import {
   captureSnapshot,
   truncate,
   withSuspendedTerminal,
+  parseCostFromPane,
 } from "../dashboard-utils";
 import {
   DEFAULT_MODEL,
@@ -52,6 +53,7 @@ function toTaskStateFile(agent: AgentState): TaskStateFile {
     createdAt: agent.createdAt,
     ownerPid: process.pid,
     worktreePath: agent.worktreePath,
+    cost: agent.cost ?? null,
   };
 }
 
@@ -80,6 +82,7 @@ async function saveToHistory(agent: AgentState, repoPath: string): Promise<void>
     finalBranch: agent.result?.finalBranch ?? null,
     error: agent.error || null,
     lastActivity: agent.lastActivity,
+    cost: agent.cost ?? null,
   };
   await upsertHistory(repoPath, task);
 }
@@ -132,6 +135,12 @@ export function useAgentActions({
       const prev = paneStateRef.current.get(agent.taskId) ?? { snapshot: "", unchangedCount: 0 };
       const next = advancePaneState(prev, snapshot);
       paneStateRef.current.set(agent.taskId, next);
+
+      // Parse cost from pane output (only meaningful for API key users)
+      const parsedCost = parseCostFromPane(lines);
+      if (parsedCost !== null && parsedCost !== agent.cost) {
+        agent.cost = parsedCost;
+      }
 
       if (next.unchangedCount === 0) {
         // Update lastActivity with the latest bullet line (Claude's text output)

--- a/src/task.ts
+++ b/src/task.ts
@@ -43,6 +43,8 @@ export interface TaskMetadata {
   /** @example "deer/fix-login-bug" */
   finalBranch: string | null;
   error: string | null;
+  /** Cumulative API cost in USD (only set when using pay-as-you-go API key) */
+  cost: number | null;
 }
 
 // ── Task History Persistence ──────────────────────────────────────────


### PR DESCRIPTION
## Task

> if a user ISN'T using subscription, so is using pay-as-you-go API token, we should show a column next to the duration column with cost

## Summary

Adds a cost tracking and display feature for users authenticated with a pay-as-you-go API token. When a user is not on a subscription plan, a cost column is shown alongside the duration column in the dashboard. Costs are parsed from Claude Code's tmux pane output and persisted alongside task state.

## Changes

- `src/agent-state.ts`: Added `cost: number | null` field to `AgentState` interface and factory/builder functions; propagate cost from persisted task and state file sources
- `src/task.ts`: Added `cost: number | null` field to `TaskMetadata` interface for persistence
- `src/dashboard-utils.ts`: Added `formatCost()` helper to format USD amounts, and `parseCostFromPane()` to extract cost values from tmux pane output lines
- `src/hooks/useAgentActions.ts`: Wire up `parseCostFromPane` during pane polling to update `agent.cost`; persist cost in task state file and history
- `src/dashboard.tsx`: Detect `api-token` credential type via preflight; render formatted cost string next to duration when available, adjusting title width accordingly

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.