### PR TITLE
🦌 Fix all oxlint linting issues

### DIFF
--- a/.kadai/actions/setup.ts
+++ b/.kadai/actions/setup.ts
@@ -5,7 +5,6 @@
 
 import { $ } from "bun";
 
-const isLinux = process.platform === "linux";
 const isMac = process.platform === "darwin";
 
 interface Tool {

--- a/src/dashboard-utils.ts
+++ b/src/dashboard-utils.ts
@@ -40,7 +40,9 @@ export function isActive(a: AgentState): boolean {
 
 /** Strip ANSI escape sequences from terminal output */
 export function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "")
+          // eslint-disable-next-line no-control-regex
           .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
 }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -69,7 +69,6 @@ export default function Dashboard({ cwd }: { cwd: string }) {
   const {
     selectedIdx,
     inputFocused,
-    setInputFocused,
     confirmQuit,
     pendingConfirmation,
     verboseMode,

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -8,7 +8,7 @@ import { writeTaskState, removeTaskState } from "../task-state";
 import type { TaskStateFile } from "../task-state";
 import type { DeerConfig } from "../config";
 import type { PreflightResult } from "../preflight";
-import { startAgent, destroyAgent, deleteTask } from "../agent";
+import { startAgent, deleteTask } from "../agent";
 import { updatePullRequest, createPullRequest } from "../git/finalize";
 import { isTmuxSessionDead, captureTmuxPane, applyTmuxStatusBar } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";

--- a/src/hooks/useKeyboardInput.ts
+++ b/src/hooks/useKeyboardInput.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useInput } from "ink";
 import type { AgentState } from "../agent-state";
 import type { Dispatch, SetStateAction } from "react";
-import { availableActions, resolveKeypress, confirmationMessage, ACTION_BINDINGS, type AgentAction } from "../state-machine";
+import { availableActions, resolveKeypress, confirmationMessage, type AgentAction } from "../state-machine";
 import { fuzzyMatch } from "../fuzzy";
 import { openUrl, isActive } from "../dashboard-utils";
 
@@ -40,7 +40,7 @@ function copyLogsToClipboard(agent: AgentState): void {
 export function useKeyboardInput({
   suspended,
   agents,
-  setAgents,
+  setAgents: _setAgents,
   logExpanded,
   setLogExpanded,
   promptHistory,
@@ -48,7 +48,7 @@ export function useKeyboardInput({
   setHistoryIdx,
   setInputDefault,
   setInputKey,
-  spawnAgent,
+  spawnAgent: _spawnAgent,
   killAgent,
   attachToAgent,
   openShell,

--- a/src/sandbox/auth-proxy.ts
+++ b/src/sandbox/auth-proxy.ts
@@ -21,7 +21,7 @@
  * so adding new APIs is just a config change.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 import { join, dirname } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";

--- a/test/dashboard.test.ts
+++ b/test/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { historicalAgent, liveTaskFromStateFile, historicalAgentFromStateFile, createAgentState } from "../src/agent-state";
+import { historicalAgent, liveTaskFromStateFile, historicalAgentFromStateFile } from "../src/agent-state";
 import { generateTaskId } from "../src/task";
 import type { PersistedTask } from "../src/task";
 import type { TaskStateFile } from "../src/task-state";

--- a/test/sandbox/auth-proxy.test.ts
+++ b/test/sandbox/auth-proxy.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, afterEach } from "bun:test";
-import { startAuthProxy, type ProxyUpstream, type AuthProxy } from "../../src/sandbox/auth-proxy";
+import { startAuthProxy, type ProxyUpstream } from "../../src/sandbox/auth-proxy";
 import { createServer, type Server } from "node:http";
 import { connect } from "node:net";
 import { mkdtemp, rm } from "node:fs/promises";

--- a/test/security/fs-escape.test.ts
+++ b/test/security/fs-escape.test.ts
@@ -8,7 +8,7 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import { createSrtRuntime } from "../../src/sandbox/srt";
 import type { SandboxCleanup } from "../../src/sandbox/runtime";
-import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/test/task-state.test.ts
+++ b/test/task-state.test.ts
@@ -1,7 +1,5 @@
 import { test, expect, describe, afterEach } from "bun:test";
-import { rm, mkdir } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+
 import {
   readTaskState,
   writeTaskState,
@@ -10,15 +8,11 @@ import {
   scanLiveTaskIds,
   type TaskStateFile,
 } from "../src/task-state";
-import * as taskModule from "../src/task";
 
 // Override dataDir for tests by monkey-patching the task-state module's dep
 // We do this by writing state files into a temp tasks dir and pointing the
 // module at it via the real filesystem under a unique temp path.
 
-function makeTempDir(): string {
-  return join(tmpdir(), `deer-task-state-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-}
 
 function makeStateFile(overrides?: Partial<TaskStateFile>): TaskStateFile {
   return {
@@ -38,19 +32,6 @@ function makeStateFile(overrides?: Partial<TaskStateFile>): TaskStateFile {
     baseBranch: "main",
     ...overrides,
   };
-}
-
-// Temporarily override dataDir to point at a temp directory
-async function withTempDataDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = makeTempDir();
-  await mkdir(join(dir, "tasks"), { recursive: true });
-  const origDataDir = (taskModule as unknown as { dataDir: () => string }).dataDir;
-
-  // We can't easily monkey-patch an ES module, so we test via the filesystem
-  // directly: the task-state functions are pure file I/O against dataDir().
-  // For these tests we'll use the real dataDir but with unique taskIds that
-  // won't collide with real state.
-  return fn(dir);
 }
 
 // Use unique taskIds per test to avoid cross-contamination

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import { generateTaskId, dataDir, historyPath, loadHistory, removeFromHistory, upsertHistory } from "../src/task";
 import type { PersistedTask } from "../src/task";
-import { rm, mkdtemp } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 


### PR DESCRIPTION
## Task

> run oxlint and fix all issues

## Summary

Ran oxlint across the codebase and resolved all reported issues. Fixes include removing unused imports and variables, prefixing intentionally unused parameters with underscores, and adding eslint-disable comments for necessary control regex patterns.

## Changes

- `.kadai/actions/setup.ts`: Remove unused `isLinux` variable
- `src/dashboard-utils.ts`: Add `eslint-disable no-control-regex` comments for intentional control character regex patterns
- `src/dashboard.tsx`: Remove unused `setInputFocused` destructured variable
- `src/hooks/useAgentActions.ts`: Remove unused `destroyAgent` import
- `src/hooks/useKeyboardInput.ts`: Remove unused `ACTION_BINDINGS` import; prefix unused `setAgents` and `spawnAgent` parameters with underscore
- `src/sandbox/auth-proxy.ts`: Remove unused `ChildProcess` type import
- `test/dashboard.test.ts`: Remove unused `createAgentState` import
- `test/sandbox/auth-proxy.test.ts`: Remove unused `AuthProxy` type import
- `test/security/fs-escape.test.ts`: Remove unused `writeFile` import
- `test/task-state.test.ts`: Remove unused imports and dead helper functions (`makeTempDir`, `withTempDataDir`)
- `test/task.test.ts`: Remove unused `mkdtemp` import

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.