### PR TITLE
🦌 Fix Shift+Enter in Kitty terminal

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -26,7 +26,9 @@ async function main() {
   // Enter alternate screen buffer
   process.stdout.write("\x1b[?1049h");
 
-  const instance = render(<Dashboard cwd={repoRoot} />);
+  const instance = render(<Dashboard cwd={repoRoot} />, {
+    kittyKeyboard: { flags: ["disambiguateEscapeCodes"] },
+  });
 
   await instance.waitUntilExit();
 

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -23,10 +23,9 @@ export function PromptInput({
   valueRef.current = value;
   cursorOffsetRef.current = cursorOffset;
 
-  // Ink v6 handles the Kitty keyboard protocol natively — it auto-detects
-  // terminal support, enables the protocol, and parses \x1b[13;2u into
-  // key.return + key.shift. We rely on that here rather than a separate raw
-  // stdin listener, which would cause double-insertion when both fire.
+  // Ink v6 Kitty keyboard protocol is opt-in via render()'s kittyKeyboard
+  // option (set in cli.tsx). When active, \x1b[13;2u is parsed into
+  // key.return + key.shift, which we handle below.
 
   useInput(
     (input, key) => {


### PR DESCRIPTION
## Task

> shift+enter in kitty still doesnt work

## Summary

Enabled the Kitty keyboard protocol explicitly via Ink's `render()` options so that Shift+Enter (`\x1b[13;2u`) is correctly parsed into `key.return + key.shift`. Previously, the code assumed Ink v6 auto-detected and enabled the protocol, but it is actually opt-in via the `kittyKeyboard` render option.

## Changes

- `src/cli.tsx`: Pass `kittyKeyboard: { flags: ["disambiguateEscapeCodes"] }` to `render()` to explicitly opt into Kitty keyboard protocol support.
- `src/components/PromptInput.tsx`: Updated comment to accurately reflect that Kitty keyboard support is opt-in (configured in `cli.tsx`) rather than auto-detected.

---

> Created by [deer](https://github.com/mm-zacharydavison/deer) — review carefully.