### PR TITLE
🦌 Add verbose logging to updatePullRequest (mirrors createPR)

### DIFF
--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -55,6 +55,8 @@ export interface UpdatePROptions {
   prompt: string;
   /** @example "https://github.com/org/repo/pull/42" */
   prUrl: string;
+  /** Verbose log callback for diagnostics */
+  onLog?: (message: string) => void;
 }
 
 interface PRMetadata {
@@ -314,23 +316,37 @@ export async function pushBranchUpdates(options: PushBranchOptions): Promise<voi
  * PR title and body from the latest diff.
  */
 export async function updatePullRequest(options: UpdatePROptions): Promise<void> {
-  const { repoPath, worktreePath, finalBranch, baseBranch, prompt, prUrl } = options;
+  const { repoPath, worktreePath, finalBranch, baseBranch, prompt, prUrl, onLog } = options;
+  const log = onLog ?? (() => {});
 
   // Remove deer internal files before staging
   await Bun.$`rm -rf ${worktreePath}/.deer-claude-config ${worktreePath}/.deer-prompt`.quiet().nothrow();
 
+  log(`[pr] Staging and committing changes...`);
   await stageAndCommit(worktreePath);
+
+  log(`[pr] Pushing branch ${finalBranch}...`);
   await pushBranch(worktreePath, finalBranch);
+  log(`[pr] Push succeeded`);
 
   // Regenerate PR metadata from the updated diff
+  log(`[pr] Finding PR template...`);
   const prTemplate = await findPRTemplate(repoPath);
-  const metadata = await generatePRMetadata(worktreePath, baseBranch, prompt, prTemplate);
+  log(`[pr] PR template: ${prTemplate ? "found" : "none"}`);
+
+  log(`[pr] Generating PR metadata via Claude...`);
+  const metadata = await generatePRMetadata(worktreePath, baseBranch, prompt, prTemplate, onLog);
+  log(`[pr] Metadata: title=${metadata.title}`);
 
   // Update the PR title and body
+  log(`[pr] Running gh pr edit ${prUrl}...`);
   const editResult = await Bun.$`gh pr edit ${prUrl} --title ${metadata.title} --body ${metadata.body}`.cwd(repoPath).quiet().nothrow();
   if (editResult.exitCode !== 0) {
-    throw new Error(`PR update failed: ${editResult.stderr.toString().trim()}`);
+    const stderr = editResult.stderr.toString().trim();
+    log(`[pr] gh pr edit failed (exit ${editResult.exitCode}): ${stderr}`);
+    throw new Error(`PR update failed: ${stderr}`);
   }
+  log(`[pr] PR updated: ${prUrl}`);
 }
 
 /**

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -413,6 +413,8 @@ export function useAgentActions({
 
     agent.updatingPr = true;
     agent.lastActivity = "Updating PR...";
+    appendLog(agent, `[pr] Starting PR update...`, true);
+    appendLog(agent, `[pr] worktreePath=${worktreePath} branch=${agent.result.finalBranch} baseBranch=${agent.baseBranch}`, true);
     setAgents((prev) => [...prev]);
 
     try {
@@ -423,10 +425,16 @@ export function useAgentActions({
         baseBranch: agent.baseBranch,
         prompt: agent.prompt,
         prUrl: agent.result.prUrl,
+        onLog: (msg) => {
+          appendLog(agent, msg, true);
+          setAgents((prev) => [...prev]);
+        },
       });
       agent.lastActivity = "PR updated";
+      appendLog(agent, `[pr] PR updated: ${agent.result.prUrl}`, true);
     } catch (err) {
-      agent.lastActivity = `PR update failed: ${err instanceof Error ? err.message : String(err)}`;
+      const msg = err instanceof Error ? err.message : String(err);
+      agent.lastActivity = `PR update failed: ${truncate(msg, 120)}`;
     } finally {
       agent.updatingPr = false;
     }


### PR DESCRIPTION
## Task

> update PR command should log, just like create PR command

## Summary

The `updatePullRequest` flow was silent compared to the `createPR` flow. This adds an `onLog` callback to `UpdatePROptions` and threads it through each step of the update process so diagnostic messages appear in the agent log panel in real time.

## Changes

- `src/git/finalize.ts`: Added optional `onLog` callback to `UpdatePROptions`; emit log messages at each stage (staging, push, template lookup, metadata generation, `gh pr edit`) and pass `onLog` through to `generatePRMetadata`
- `src/hooks/useAgentActions.ts`: Wire up `onLog` when calling `updatePullRequest`, emitting each message via `appendLog`; add start/completion log lines; truncate error messages to 120 chars for the activity label

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.