### PR TITLE
🦌 Fix screenshot demo not filling full terminal width

### DIFF
--- a/.kadai/actions/screenshot.ts
+++ b/.kadai/actions/screenshot.ts
@@ -3,7 +3,6 @@
 // kadai:emoji 📸
 // kadai:description Launch deer in demo mode with mock tasks for README screenshots
 
-import { $ } from "bun";
 import { join } from "node:path";
 
 async function main() {
@@ -13,10 +12,14 @@ async function main() {
   console.log("🦌 Launching deer in demo mode...");
   console.log(`   Press q to quit\n`);
 
-  await $`bun run ${cliPath} --demo`.env({
-    ...process.env,
-    FORCE_COLOR: "1",
+  const proc = Bun.spawn(["bun", "run", cliPath, "--demo"], {
+    env: { ...process.env, FORCE_COLOR: "1" },
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
   });
+
+  await proc.exited;
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Task

> the screenshot demo still does not fit full terminal width (the real dashboard does)

## Summary

The screenshot demo was launched via Bun's `$` shell template tag, which pipes stdio through a shell subprocess and can interfere with terminal size detection. Switching to `Bun.spawn` with `stdin/stdout/stderr` all set to `"inherit"` passes the real TTY file descriptors directly to the child process, so deer can read the correct terminal dimensions and render at full width.

## Changes

- `.kadai/actions/screenshot.ts`: Replaced `$\`bun run ${cliPath} --demo\`` shell invocation with `Bun.spawn(["bun", "run", cliPath, "--demo"], { stdin: "inherit", stdout: "inherit", stderr: "inherit" })` and awaits `proc.exited`; removed the unused `$` import from `bun`.

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.