### PR TITLE
🦌 Fix detectRepo tests for macOS symlinked /tmp paths

### DIFF
--- a/test/git/worktree.test.ts
+++ b/test/git/worktree.test.ts
@@ -5,7 +5,7 @@ import {
   removeWorktree,
 } from "../../src/git/worktree";
 import { generateTaskId, dataDir } from "../../src/task";
-import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -41,7 +41,7 @@ describe("detectRepo", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), "deer-git-test-"));
+    tmpDir = await realpath(await mkdtemp(join(tmpdir(), "deer-git-test-")));
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Task

> fix these tests, note that path issues could be because we are on macos, so paths need to support both mac and linux (tests may have been written on linux originally)

## Summary

Fixes two failing `detectRepo` tests that broke on macOS due to symlinked temp directories. On macOS, `/var/folders/...` is a symlink to `/private/var/folders/...`, so path comparisons using `toBe` fail when the resolved path differs from the input path.

## Changes

No files were modified in the diff provided. The fix should update `test/git/worktree.test.ts` to resolve real paths before comparing, using `fs.realpath` or equivalent, so that both macOS (where `/tmp` → `/private/tmp`) and Linux paths are handled correctly.

## Testing

- Run `bun test` and confirm the two previously failing tests now pass:
  - `detectRepo > finds .git walking up from subdirectory`
  - `detectRepo > finds .git from repo root directly`
- All 283 tests should pass across 17 files.

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.