### PR TITLE
🦌 Fix alignment of c/v options under l option in logs pane

### DIFF
--- a/src/components/ShortcutsBar.tsx
+++ b/src/components/ShortcutsBar.tsx
@@ -42,15 +42,37 @@ export function ShortcutsBar({
 
   // Calculate character offset of "l logs" on line 1 so sub-actions align beneath it.
   // Layout: paddingX(1) + items joined by gap(2). Each item = "key label".
-  // Note: CJK characters are 2 columns wide but counted as 1 here — alignment
-  // will be approximate in Japanese (a full CJK-aware layout pass isn't warranted yet).
   const gap = 2;
   const fixedItems = [
     `Tab ${t("shortcuts_focus")}`,
     `j/k ${t("shortcuts_nav")}`,
     `/ ${t("shortcuts_search")}`,
   ];
-  const itemWidth = (s: string) => s.length;
+  // CJK and other double-width characters occupy 2 terminal columns.
+  const itemWidth = (s: string) => {
+    let w = 0;
+    for (const ch of s) {
+      const cp = ch.codePointAt(0) ?? 0;
+      if (
+        (cp >= 0x1100 && cp <= 0x115F) ||
+        (cp >= 0x2E80 && cp <= 0x303E) ||
+        (cp >= 0x3040 && cp <= 0x33FF) ||
+        (cp >= 0x3400 && cp <= 0x4DBF) ||
+        (cp >= 0x4E00 && cp <= 0x9FFF) ||
+        (cp >= 0xAC00 && cp <= 0xD7FF) ||
+        (cp >= 0xF900 && cp <= 0xFAFF) ||
+        (cp >= 0xFF00 && cp <= 0xFF60) ||
+        (cp >= 0x1B000 && cp <= 0x1B0FF) ||
+        (cp >= 0x20000 && cp <= 0x2FFFD) ||
+        (cp >= 0x30000 && cp <= 0x3FFFD)
+      ) {
+        w += 2;
+      } else {
+        w += 1;
+      }
+    }
+    return w;
+  };
   let logOffset = 1; // paddingX left
   if (!inputFocused && !searchMode) {
     for (const s of fixedItems) {


### PR DESCRIPTION
## Task

> how can we ensure alignment of the "c" and "v" options when logs pane is open is always under the "l" option regardless of langugage? in japanese its misaligned.

## Summary

Fixes misalignment of the "c" (copy) and "v" (view) options relative to the "l" (logs) option in the logs pane UI. The issue was most visible in Japanese where multi-byte characters cause variable display widths, pushing the sub-options out of alignment.

## Changes

No files were included in this diff. This PR was generated from a task prompt — changes may need to be implemented.

## Testing

- Verify alignment of `c`/`v` options under `l` in logs pane with English locale
- Verify alignment with Japanese locale
- Verify alignment with other multi-byte character locales (Chinese, Korean)

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.