### PR TITLE
🦌 Add Ctrl+C to clear the prompt input

### DIFF
--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -66,10 +66,21 @@ export function PromptInput({
       if (
         key.upArrow ||
         key.downArrow ||
-        (key.ctrl && input === "c") ||
         key.tab ||
         (key.shift && key.tab)
       ) {
+        return;
+      }
+
+      if (key.ctrl && input === "c") {
+        if (valueRef.current.length > 0) {
+          valueRef.current = "";
+          cursorOffsetRef.current = 0;
+          pasteBlocksRef.current = [];
+          setValue("");
+          setCursorOffset(0);
+          setPasteBlocks([]);
+        }
         return;
       }
 


### PR DESCRIPTION
## Task

> we want to add CTRL+C to clear the promptinput, like how claude code works

## Summary

Adds Ctrl+C keyboard shortcut to clear the prompt input field, mirroring the behavior in Claude Code where pressing Ctrl+C clears the current input rather than interrupting the process.

## Changes

No files were included in the diff for this PR.

## Testing

- Manually verify that pressing Ctrl+C while the prompt input is focused clears the input field
- Verify that Ctrl+C does not interfere with other keyboard shortcuts or browser defaults

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.