### PR TITLE
🦌 Fix Claude tmux pane width to match host terminal

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -154,7 +154,7 @@ export async function launchSandbox(options: SandboxOptions): Promise<SandboxSes
     `HOME=${sandboxEnv.HOME}`,
     `TERM=${sandboxEnv.TERM}`,
     "tmux", "new-session", "-d", "-s", sessionName,
-    "-x", "200", "-y", "50",
+    "-x", String(process.stdout.columns || 220), "-y", String(process.stdout.rows || 50),
     "sh", "-c", preamble,
   ], { stdout: "pipe", stderr: "pipe" });
   const createCode = await createProc.exited;


### PR DESCRIPTION
## Task

> the column width of the claude instance (tmux pane?) is too narrow, we would like it to match the host and fill the width of the terminal emulator

## Summary

Fixes the column width of the Claude tmux pane so it matches the host terminal width instead of using a narrower default.

## Changes

No files were modified in this diff.

## Testing

- Verify the Claude pane fills the full width of the terminal emulator after the fix

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.