### PR TITLE
🦌 Fix duplicate retry shortcut in TUI shortcut section

### DIFF
--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -110,8 +110,11 @@ export const ACTION_BINDINGS: Record<AgentAction, ActionBinding> = {
 export function availableActions(ctx: AgentContext): AgentAction[] {
   const base = [...ACTIONS_BY_STATE[ctx.status]];
   // Idle agents can create/update PRs and retry (Claude is at rest)
-  if (ctx.isIdle && !base.includes("create_pr")) {
-    base.push("create_pr", "open_pr", "update_pr", "retry");
+  if (ctx.isIdle) {
+    if (!base.includes("create_pr")) base.push("create_pr");
+    if (!base.includes("open_pr")) base.push("open_pr");
+    if (!base.includes("update_pr")) base.push("update_pr");
+    if (!base.includes("retry")) base.push("retry");
   }
   // copy_logs and toggle_verbose are available when the log panel is open
   if (ctx.logExpanded) {


### PR DESCRIPTION
## Task

> retry can appear multiple times in the shortcut section in the TUI for some reason

## Summary

Fixes an issue where the "retry" shortcut was appearing multiple times in the TUI shortcut section.

## Changes

No diff was provided for this PR.

## Testing

- Manually verify the TUI shortcut section only shows "retry" once

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.