### PR TITLE
🦌 Fix backspace key not registering when held down

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -24,7 +24,7 @@ async function main() {
     process.stdout.write("\x1b[?1049h");
 
     const instance = render(<DemoDashboard />, {
-      kittyKeyboard: { flags: ["disambiguateEscapeCodes"] },
+      kittyKeyboard: { flags: ["disambiguateEscapeCodes", "reportEventTypes"] },
     });
 
     await instance.waitUntilExit();
@@ -51,7 +51,7 @@ async function main() {
   process.stdout.write("\x1b[?1049h");
 
   const instance = render(<Dashboard cwd={repoRoot} />, {
-    kittyKeyboard: { flags: ["disambiguateEscapeCodes"] },
+    kittyKeyboard: { flags: ["disambiguateEscapeCodes", "reportEventTypes"] },
   });
 
   await instance.waitUntilExit();

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -63,6 +63,8 @@ export function PromptInput({
 
   useInput(
     (input, key) => {
+      if (key.eventType === "release") return;
+
       if (
         key.upArrow ||
         key.downArrow ||

--- a/src/hooks/useKeyboardInput.ts
+++ b/src/hooks/useKeyboardInput.ts
@@ -268,6 +268,7 @@ export function useKeyboardInput({
 
   useInput((input, key) => {
     if (suspended) return;
+    if (key.eventType === "release") return;
 
     if (handleSearchInput(input, key)) return;
     if (handleQuitInput(input)) return;


### PR DESCRIPTION
## Task

> holding backspace doesnt work, we have to keep pressing it over and over

## Summary

Fixes an issue where holding the backspace key did not continuously delete characters — users had to repeatedly press it instead of holding it down.

## Changes

No files were included in the diff for this PR.

## Testing

- Hold the backspace key and verify characters are continuously deleted without needing to repeatedly press the key.

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.