### PR TITLE
🦌 Make quit non-destructive, remove confirmation prompt

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -74,7 +74,6 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
   const {
     selectedIdx,
     inputFocused,
-    confirmQuit,
     pendingConfirmation,
     verboseMode,
     searchMode,
@@ -195,14 +194,6 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
           <Text color="yellow" bold>{pendingConfirmation.message}</Text>
         </Box>
       )}
-      {confirmQuit && (
-        <Box paddingX={1}>
-          <Text color="yellow" bold>
-            {t("quit_confirm", { n: activeCount, s: activeCount !== 1 ? "s" : "" })}
-          </Text>
-        </Box>
-      )}
-
       {/* Preflight errors */}
       {preflight && !preflight.ok && (
         <Box flexDirection="column" paddingX={1}>

--- a/src/hooks/useKeyboardInput.ts
+++ b/src/hooks/useKeyboardInput.ts
@@ -60,7 +60,6 @@ export function useKeyboardInput({
 }: KeyboardInputDeps) {
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [inputFocused, setInputFocused] = useState(true);
-  const [confirmQuit, setConfirmQuit] = useState(false);
   const [pendingConfirmation, setPendingConfirmation] = useState<{
     action: AgentAction;
     agent: AgentState;
@@ -124,12 +123,6 @@ export function useKeyboardInput({
 
   function handleQuitInput(input: string): boolean {
     if (input === "q" && !inputFocused) {
-      const running = agents.filter(isActive);
-      if (running.length > 0 && !confirmQuit) {
-        setConfirmQuit(true);
-        return true;
-      }
-      for (const a of running) killAgent(a);
       exit();
       return true;
     }
@@ -137,17 +130,6 @@ export function useKeyboardInput({
   }
 
   function handleConfirmationInput(input: string): boolean {
-    if (confirmQuit) {
-      if (input === "y" || input === "Y") {
-        const running = agents.filter(isActive);
-        for (const a of running) killAgent(a);
-        exit();
-      } else {
-        setConfirmQuit(false);
-      }
-      return true;
-    }
-
     if (pendingConfirmation) {
       if (input === "y" || input === "Y") {
         executeAction(pendingConfirmation.action, pendingConfirmation.agent);
@@ -288,7 +270,6 @@ export function useKeyboardInput({
     selectedIdx,
     inputFocused,
     setInputFocused,
-    confirmQuit,
     pendingConfirmation,
     verboseMode,
     searchMode,


### PR DESCRIPTION
## Task

> quitting deer should not actually clean anything up (we might relaunch and want to reacquire the instances), thus we also probably dont need the confirmation warning when quitting as quitting is not desctructive

## Summary

Quit (`q`) now exits immediately without killing running agents or prompting for confirmation. Since deer can relaunch and reacquire existing instances, cleanup on quit is unnecessary and the confirmation step added friction with no benefit.

## Changes

- `src/hooks/useKeyboardInput.ts`: Removed `confirmQuit` state, quit confirmation logic, and agent kill-on-quit behavior — `q` now calls `exit()` directly
- `src/dashboard.tsx`: Removed the `confirmQuit` UI banner from the dashboard render

## Testing

- Press `q` with active agents running — should exit immediately without prompt or cleanup
- Relaunch deer after quitting — existing agents should still be reacquirable

## Checklist

- [ ] Tests pass (`bun test`)
- [ ] No new security vulnerabilities introduced
- [ ] Relevant documentation updated

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.