### PR TITLE
🦌 Link screencast cover image to YouTube video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you want to parallelize `claude` agents, but don't like the complexity of age
 
 ## Screencast
 
-https://youtu.be/1hvmO04NFNc
+[![snapshot from the screencast](assets/screencast-cover.png)](https://youtu.be/1hvmO04NFNc)
 
 ## Goals
 


### PR DESCRIPTION
## Task

> use the screencast cover as a hyperlink for the youtube video in README ## Screencast
>
> ![snapshot from the screencast](assets/screencast-cover.png)
>
> https://youtu.be/1hvmO04NFNc

## Summary

Wrapped the screencast cover image in the README with a hyperlink pointing to the YouTube video, so clicking the image navigates directly to the video.

## Changes

- No file diffs were provided; the change involves wrapping the existing `![snapshot from the screencast](assets/screencast-cover.png)` image in the README with a link to `https://youtu.be/1hvmO04NFNc`

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.