### PR TITLE
🦌 Scope tasks to current repo with toggle for all

### DIFF
--- a/src/components/ShortcutsBar.tsx
+++ b/src/components/ShortcutsBar.tsx
@@ -13,6 +13,7 @@ interface ShortcutsBarProps {
   verboseMode: boolean;
   logExpanded: boolean;
   preflight: PreflightResult | null;
+  showAll: boolean;
 }
 
 export function ShortcutsBar({
@@ -22,6 +23,7 @@ export function ShortcutsBar({
   verboseMode,
   logExpanded,
   preflight,
+  showAll,
 }: ShortcutsBarProps) {
   let mainActions: AgentAction[] = [];
   let logSubActions: AgentAction[] = [];
@@ -108,6 +110,7 @@ export function ShortcutsBar({
                     <Text dimColor> {t(("action_" + action) as StringKey)}</Text>
                   </Text>
                 ))}
+                <Text><Text bold color="white">a</Text><Text dimColor> {showAll ? "this repo" : "all repos"}</Text></Text>
                 <Text><Text bold color="white">q</Text><Text dimColor> {t("shortcuts_quit")}</Text></Text>
               </>
             )}

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -46,7 +46,7 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
   const [animTick, setAnimTick] = useState(0);
   const configRef = useRef<DeerConfig | null>(null);
 
-  const { agents, setAgents, agentsRef, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, liveSessionIdsRef, syncWithHistory } = useAgentSync(cwd, configRef, mockAgents);
+  const { agents, setAgents, agentsRef, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, liveSessionIdsRef, syncWithHistory, showAll, setShowAll } = useAgentSync(cwd, configRef, mockAgents);
 
   const {
     promptHistory,
@@ -100,6 +100,8 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
     deleteAgent,
     retryAgent,
     exit,
+    showAll,
+    setShowAll,
   });
 
   // ── Load config + preflight + start config guard ───────────────────
@@ -184,7 +186,10 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
       {/* Header */}
       <Box paddingX={1} justifyContent="space-between">
         <Text bold>{t("header_title")}</Text>
-        <Text dimColor>{activeCount > 0 ? t("header_active", { n: activeCount }) : t("header_idle")}</Text>
+        <Box gap={2}>
+          {showAll && <Text dimColor>all repos</Text>}
+          <Text dimColor>{activeCount > 0 ? t("header_active", { n: activeCount }) : t("header_idle")}</Text>
+        </Box>
       </Box>
       <Text>{"─".repeat(termWidth)}</Text>
 
@@ -345,6 +350,7 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
         verboseMode={verboseMode}
         logExpanded={logExpanded}
         preflight={preflight}
+        showAll={showAll}
       />
     </Box>
   );

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -38,7 +38,7 @@ interface AgentRuntime {
   timer: ReturnType<typeof setInterval>;
 }
 
-function toTaskStateFile(agent: AgentState): TaskStateFile {
+function toTaskStateFile(agent: AgentState, repoPath: string): TaskStateFile {
   return {
     taskId: agent.taskId,
     prompt: agent.prompt,
@@ -55,17 +55,18 @@ function toTaskStateFile(agent: AgentState): TaskStateFile {
     ownerPid: process.pid,
     worktreePath: agent.worktreePath,
     cost: agent.cost ?? null,
+    repoPath,
   };
 }
 
 /** Persist agent state to the live task state file (fire-and-forget). */
-function persistState(agent: AgentState): void {
-  writeTaskState(toTaskStateFile(agent)).catch(() => {});
+function persistState(agent: AgentState, repoPath: string): void {
+  writeTaskState(toTaskStateFile(agent, repoPath)).catch(() => {});
 }
 
 /** Persist agent state to the live task state file (awaited). */
-async function persistStateAsync(agent: AgentState): Promise<void> {
-  await writeTaskState(toTaskStateFile(agent));
+async function persistStateAsync(agent: AgentState, repoPath: string): Promise<void> {
+  await writeTaskState(toTaskStateFile(agent, repoPath));
 }
 
 async function saveToHistory(agent: AgentState, repoPath: string): Promise<void> {
@@ -155,7 +156,7 @@ export function useAgentActions({
           if (activity !== agent.lastActivity) {
             agent.lastActivity = activity;
             appendLog(agent, `[tmux] ${lastOutput}`);
-            await persistStateAsync(agent);
+            await persistStateAsync(agent, cwd);
             setAgents((prev) => [...prev]);
           }
         }
@@ -166,11 +167,11 @@ export function useAgentActions({
         agent.idle = true;
         agent.lastActivity = t("activity_idle_attach");
         appendLog(agent, t("log_deer_idle"));
-        await persistStateAsync(agent);
+        await persistStateAsync(agent, cwd);
         setAgents((prev) => [...prev]);
       } else if (next.unchangedCount === 0 && agent.idle) {
         agent.idle = false;
-        await persistStateAsync(agent);
+        await persistStateAsync(agent, cwd);
         setAgents((prev) => [...prev]);
       }
     }
@@ -242,12 +243,12 @@ export function useAgentActions({
       const timer = setInterval(() => {
         if (!agent.idle) agent.elapsed++;
         ticks++;
-        if (ticks % 10 === 0) persistState(agent);
+        if (ticks % 10 === 0) persistState(agent, cwd);
         setAgents((prev) => [...prev]);
       }, 1000);
 
       runtimeRef.current.set(taskId, { abortController, timer });
-      await persistStateAsync(agent);
+      await persistStateAsync(agent, cwd);
 
       agent.status = transition(agent.status, "SETUP_COMPLETE") ?? agent.status;
       appendLog(agent, t("log_running_started", { session: handle.sessionName }));
@@ -308,7 +309,7 @@ export function useAgentActions({
     }).exited.catch(() => {});
 
     saveToHistory(agent, cwd);
-    persistState(agent);
+    persistState(agent, cwd);
     setAgents((prev) => [...prev]);
   }, [cwd]);
 
@@ -529,12 +530,12 @@ export function useAgentActions({
     const timer = setInterval(() => {
       if (!agent.idle) agent.elapsed++;
       ticks++;
-      if (ticks % 10 === 0) persistState(agent);
+      if (ticks % 10 === 0) persistState(agent, cwd);
       setAgents((prev) => [...prev]);
     }, 1000);
 
     runtimeRef.current.set(agent.taskId, { abortController, timer });
-    await persistStateAsync(agent); // Claim ownership: update ownerPid
+    await persistStateAsync(agent, cwd); // Claim ownership: update ownerPid
     appendLog(agent, t("log_deer_resuming"));
     setAgents((prev) => [...prev]);
 

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { watch } from "node:fs";
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { MutableRefObject } from "react";
-import { loadHistory, dataDir } from "../task";
+import { loadHistory, loadAllHistory, dataDir } from "../task";
 import type { SandboxCleanup } from "../sandbox/index";
 import { isTmuxSessionDead } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";
@@ -14,6 +14,7 @@ import { TASK_SYNC_DEBOUNCE_MS, TASK_SYNC_SAFETY_POLL_MS } from "../constants";
 
 export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig | null>, mockAgents?: AgentState[]) {
   const [agents, setAgents] = useState<AgentState[]>(mockAgents ?? []);
+  const [showAll, setShowAll] = useState(false);
   const agentsRef = useRef(agents);
   agentsRef.current = agents;
   const deletedTaskIdsRef = useRef(new Set<string>());
@@ -46,16 +47,22 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
         .filter(id => !deletedTaskIdsRef.current.has(id))
         .map(async id => ({ id, state: await readTaskState(id) })),
     );
-    const liveStateFiles = new Map(
+    const allLiveStateFiles = new Map(
       liveStateResults
         .filter((r): r is { id: string; state: NonNullable<typeof r.state> } => r.state !== null)
         .map(r => [r.id, r.state]),
     );
 
+    // In repo-scoped mode, hide live tasks that belong to a different repo.
+    // Tasks without a repoPath (written by older deer versions) are always shown.
+    const liveStateFiles = showAll
+      ? allLiveStateFiles
+      : new Map([...allLiveStateFiles].filter(([, s]) => !s.repoPath || s.repoPath === cwd));
+
     // Completed tasks: JSONL history (only non-running entries now that live tasks
     // use state.json; running entries are kept as a fallback for tasks started by
     // older deer versions that did not write state.json)
-    const allFileTasks = await loadHistory(cwd);
+    const allFileTasks = showAll ? await loadAllHistory() : await loadHistory(cwd);
     const fileTasks = allFileTasks.filter(t => !deletedTaskIdsRef.current.has(t.taskId));
 
     const currentAgents = agentsRef.current;
@@ -148,7 +155,7 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       });
 
     if (changed) setAgents(newAgents);
-  }, [cwd]);
+  }, [cwd, showAll]);
 
   // ── Load on mount ──────────────────────────────────────────────────
 
@@ -187,5 +194,5 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
     };
   }, [syncWithHistory]);
 
-  return { agents, setAgents, agentsRef, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, liveSessionIdsRef, syncWithHistory };
+  return { agents, setAgents, agentsRef, deletedTaskIdsRef, baseBranchRef, restoredProxiesRef, liveSessionIdsRef, syncWithHistory, showAll, setShowAll };
 }

--- a/src/hooks/useKeyboardInput.ts
+++ b/src/hooks/useKeyboardInput.ts
@@ -26,6 +26,8 @@ interface KeyboardInputDeps {
   deleteAgent: (agent: AgentState) => void;
   retryAgent: (agent: AgentState) => void;
   exit: () => void;
+  showAll: boolean;
+  setShowAll: Dispatch<SetStateAction<boolean>>;
 }
 
 function copyLogsToClipboard(agent: AgentState): void {
@@ -57,6 +59,8 @@ export function useKeyboardInput({
   deleteAgent,
   retryAgent,
   exit,
+  showAll,
+  setShowAll,
 }: KeyboardInputDeps) {
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [inputFocused, setInputFocused] = useState(true);
@@ -168,6 +172,11 @@ export function useKeyboardInput({
       setSearchMode(true);
       setSearchQuery("");
       setSearchMatchIdx(0);
+      return;
+    }
+
+    if (input === "a") {
+      setShowAll((prev) => !prev);
       return;
     }
 

--- a/src/task-state.ts
+++ b/src/task-state.ts
@@ -25,6 +25,8 @@ export interface TaskStateFile extends TaskMetadata {
   worktreePath: string;
   /** Git branch to base the worktree on (e.g. "main") */
   baseBranch: string;
+  /** Absolute path of the git repository this task belongs to */
+  repoPath?: string;
 }
 
 // ── Paths ─────────────────────────────────────────────────────────────

--- a/src/task.ts
+++ b/src/task.ts
@@ -73,6 +73,35 @@ export function historyPath(repoPath: string): string {
 }
 
 /**
+ * Load all persisted tasks across all repos.
+ * Scans every JSONL file in the history directory and returns a combined list.
+ * Returns an empty array if the history directory does not exist.
+ */
+export async function loadAllHistory(): Promise<PersistedTask[]> {
+  const historyDir = `${dataDir()}/history`;
+  const tasks: PersistedTask[] = [];
+  try {
+    const glob = new Bun.Glob("*.jsonl");
+    for await (const match of glob.scan({ cwd: historyDir })) {
+      const file = Bun.file(`${historyDir}/${match}`);
+      if (!(await file.exists())) continue;
+      const text = await file.text();
+      for (const line of text.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          tasks.push(JSON.parse(line));
+        } catch {
+          // Skip malformed lines
+        }
+      }
+    }
+  } catch {
+    // History dir may not exist yet
+  }
+  return tasks;
+}
+
+/**
  * Load all persisted tasks for a repo.
  * Returns an empty array if no history file exists.
  */

--- a/test/task-state.test.ts
+++ b/test/task-state.test.ts
@@ -116,6 +116,22 @@ describe("readTaskState", () => {
     const loaded = await readTaskState(taskId);
     expect(loaded!.error).toBe("Claude exited with code 1");
   });
+
+  test("persists repoPath field", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+    await writeTaskState(makeStateFile({ taskId, repoPath: "/home/user/my-project" }));
+    const loaded = await readTaskState(taskId);
+    expect(loaded!.repoPath).toBe("/home/user/my-project");
+  });
+
+  test("repoPath is undefined when not set", async () => {
+    const taskId = uniqueTaskId();
+    createdIds.push(taskId);
+    await writeTaskState(makeStateFile({ taskId }));
+    const loaded = await readTaskState(taskId);
+    expect(loaded!.repoPath).toBeUndefined();
+  });
 });
 
 describe("removeTaskState", () => {

--- a/test/task.test.ts
+++ b/test/task.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, afterEach } from "bun:test";
-import { generateTaskId, dataDir, historyPath, loadHistory, removeFromHistory, upsertHistory } from "../src/task";
+import { generateTaskId, dataDir, historyPath, loadHistory, loadAllHistory, removeFromHistory, upsertHistory } from "../src/task";
 import type { PersistedTask } from "../src/task";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -261,6 +261,27 @@ describe("history persistence", () => {
     expect(loaded[1].prompt).toBe("the task");
     expect(loaded[1].status).toBe("cancelled");
     expect(loaded[2].prompt).toBe("task after");
+  });
+
+  test("loadAllHistory returns tasks from all repos", async () => {
+    const repoA = makeFakeDataDir();
+    const repoB = makeFakeDataDir();
+    const taskA = makeTask({ prompt: "task in repo A" });
+    const taskB = makeTask({ prompt: "task in repo B" });
+
+    await upsertHistory(repoA, taskA);
+    await upsertHistory(repoB, taskB);
+
+    const all = await loadAllHistory();
+    const ids = all.map((t) => t.taskId);
+    expect(ids).toContain(taskA.taskId);
+    expect(ids).toContain(taskB.taskId);
+  });
+
+  test("loadAllHistory returns empty array when history dir has no matching files", async () => {
+    // This just verifies it doesn't throw on a (potentially) empty dir
+    const result = await loadAllHistory();
+    expect(Array.isArray(result)).toBe(true);
   });
 
   test("running tasks can be persisted and loaded", async () => {


### PR DESCRIPTION
## Task

> tasks should be scoped to repos (so if i run a deer task in one repo and go run deer in another, my TUI doesn't show other deer tasks by default) this behaviour can be toggled with 'a' shortcut (show all).

## Summary

This PR implements repository-scoped task filtering in the TUI. By default, only tasks belonging to the current repository are shown. Users can press `a` to toggle between repo-scoped and global (all) task views.

## Changes

No file changes were included in this diff.

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.