### PR TITLE
🦌 Fix tmux session attach when running inside tmux

### DIFF
--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -329,15 +329,19 @@ export function useAgentActions({
     if (!agent.taskId) return;
     const sessionName = `deer-${agent.taskId}`;
 
-    await withSuspendedTerminal(setSuspended, async () => {
-      // Small delay to let any pending keypress (e.g. the Enter that triggered
-      // attach) flush through before tmux takes over stdin.
-      await Bun.sleep(50);
+    if (process.env.TMUX) {
+      // Already inside tmux — switch-client is non-blocking; deer keeps running.
       const { spawnSync } = await import("node:child_process");
-      spawnSync("tmux", ["attach", "-t", sessionName], {
-        stdio: "inherit",
+      spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
+    } else {
+      await withSuspendedTerminal(setSuspended, async () => {
+        // Small delay to let any pending keypress (e.g. the Enter that triggered
+        // attach) flush through before tmux takes over stdin.
+        await Bun.sleep(50);
+        const { spawnSync } = await import("node:child_process");
+        spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
       });
-    });
+    }
 
     // Default to idle on detach and seed the pane state with the current
     // snapshot. If Claude is actually doing something, the poll loop will
@@ -361,15 +365,21 @@ export function useAgentActions({
     const shell = process.env.SHELL ?? "/bin/sh";
     const sessionName = `deer-shell-${agent.taskId}`;
 
-    await withSuspendedTerminal(setSuspended, async () => {
-      await Bun.sleep(50);
-      const { spawnSync } = await import("node:child_process");
-      // Create detached session (no-op if already exists); then apply the
-      // deer status bar, then attach — so ctrl+b d returns to deer like attach.
-      spawnSync("tmux", ["new-session", "-d", "-s", sessionName, "-c", worktreePath, shell]);
-      await applyTmuxStatusBar(sessionName);
-      spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
-    });
+    const { spawnSync } = await import("node:child_process");
+    // Create detached session (no-op if already exists); then apply the
+    // deer status bar, then switch/attach — so ctrl+b d returns to deer.
+    spawnSync("tmux", ["new-session", "-d", "-s", sessionName, "-c", worktreePath, shell]);
+    await applyTmuxStatusBar(sessionName);
+
+    if (process.env.TMUX) {
+      // Already inside tmux — switch-client is non-blocking; deer keeps running.
+      spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
+    } else {
+      await withSuspendedTerminal(setSuspended, async () => {
+        await Bun.sleep(50);
+        spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
+      });
+    }
   }, [setSuspended]);
 
   // ── Create PR ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Task

> Cannot attach to tmux sessions when deer is launched inside tmux. Deer starts fine inside tmux, but attaching session fails.

## Summary

When deer is already running inside a tmux session, calling `tmux attach` fails because you cannot attach to a session from within an existing tmux client. The fix detects the `TMUX` environment variable and uses `switch-client` instead of `attach` in that case. `switch-client` is non-blocking and works correctly from within a nested tmux context, allowing deer to remain running while the user is taken to the target session.

## Changes

- `src/hooks/useAgentActions.ts`: Updated both the task session attach and the shell session attach handlers to check `process.env.TMUX`. When inside tmux, `switch-client -t <session>` is used instead of `attach -t <session>`. The `withSuspendedTerminal` wrapper and sleep delay are only applied in the non-nested (plain terminal) path, since `switch-client` is non-blocking and does not require suspending the UI.

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.