### PR TITLE
🦌 Expand sandbox gitconfig to suppress git warnings

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -240,7 +240,28 @@ export async function startAgent(options: AgentRunOptions): Promise<AgentHandle>
   // Write a minimal gitconfig to the task dir so git never reads ~/.gitconfig
   // (which is blocked by the sandbox). GIT_CONFIG_GLOBAL points here instead.
   const gitconfigPath = join(dirname(worktreePath), "gitconfig");
-  await Bun.write(gitconfigPath, "[user]\n\tname = deer-agent\n\temail = deer@noreply\n");
+  await Bun.write(
+    gitconfigPath,
+    [
+      "[user]",
+      "\tname = deer-agent",
+      "\temail = deer@noreply",
+      "[init]",
+      "\tdefaultBranch = main",
+      "[pull]",
+      "\trebase = false",
+      "[merge]",
+      "\tconflictstyle = merge",
+      "[safe]",
+      "\tdirectory = *",
+      "[advice]",
+      "\tdetachedHead = false",
+      "\tskippedCherryPicks = false",
+      "\twaitingForEditor = false",
+      "[credential]",
+      "\thelper =",
+    ].join("\n") + "\n"
+  );
 
   onStatus?.({ phase: "setup", message: "Starting sandbox..." });
 


### PR DESCRIPTION
## Task

> Sandbox denies paths required for git operations. ~/.config/git (global gitignore) and ~/.gitconfig are in the denyRead list, causing warnings or errors on any git command inside the sandbox. allowing this likely has security concerns. Explain the security risks.

## Summary

The sandbox blocks access to `~/.gitconfig` and `~/.config/git`, causing git to emit warnings or errors during agent operations. Rather than allowing sandbox access to these user-level config files (which would expose potentially sensitive credential helpers, signing keys, or personal config), the existing minimal gitconfig written to the task directory is expanded to cover the settings that git would otherwise look for globally.

## Changes

- `src/agent.ts`: Expanded the synthetic gitconfig written to the task directory to include `[init]`, `[pull]`, `[merge]`, `[safe]`, `[advice]`, and `[credential]` sections, suppressing common git warnings and ensuring predictable behavior without needing access to the user's real gitconfig

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.