### PR TITLE
🦌 Use Sonnet instead of Haiku for PR metadata generation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,9 @@ export const BYPASS_DIALOG_KEY_DELAY_MS = 200;
 /** Max diff length sent to Claude for PR metadata generation */
 export const MAX_DIFF_FOR_PR_METADATA = 20_000;
 
+/** Model used to generate PR metadata (title, body, branch name) */
+export const PR_METADATA_MODEL = "sonnet";
+
 /** Debounce delay for cross-instance task state sync */
 export const TASK_SYNC_DEBOUNCE_MS = 100;
 

--- a/src/git/finalize.ts
+++ b/src/git/finalize.ts
@@ -3,7 +3,7 @@
  */
 
 import { join } from "path";
-import { MAX_DIFF_FOR_PR_METADATA } from "../constants";
+import { MAX_DIFF_FOR_PR_METADATA, PR_METADATA_MODEL } from "../constants";
 import { getPRLanguage } from "../i18n";
 
 /**
@@ -191,7 +191,7 @@ Diff:
 ${truncatedDiff}`;
 
   try {
-    const proc = Bun.spawn(["claude", "-p", metadataPrompt, "--output-format", "json"], {
+    const proc = Bun.spawn(["claude", "-p", metadataPrompt, "--model", PR_METADATA_MODEL, "--output-format", "json"], {
       stdout: "pipe",
       stderr: "pipe",
       timeout: 60_000,


### PR DESCRIPTION
## Task

> we're getting lots of hallucinations in the PR descriptions, lets try using sonnet instead of haiku

## Summary

Switches the model used for PR metadata generation (title, body, branch name) from Haiku to Sonnet to reduce hallucinations in generated PR descriptions.

## Changes

- `src/constants.ts`: Added `PR_METADATA_MODEL` constant set to `"sonnet"`
- `src/git/finalize.ts`: Passes `--model PR_METADATA_MODEL` flag to the Claude CLI invocation for PR metadata generation

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.