### PR TITLE
🦌 Add @ context picker for starting tasks on existing branches

### DIFF
--- a/src/components/ContextChipBar.tsx
+++ b/src/components/ContextChipBar.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { ContextChip } from "../context/types";
+
+/**
+ * Renders the row of resolved context chips above the prompt input.
+ * The last chip is dismissed by pressing Backspace on an empty prompt.
+ * Returns null when there are no chips (renders nothing).
+ */
+export function ContextChipBar({ chips }: { chips: ContextChip[] }) {
+  if (chips.length === 0) return null;
+
+  return (
+    <Box paddingX={1} gap={1}>
+      {chips.map((chip, i) => (
+        <Text key={i} color="cyan">[{chip.label} ×]</Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/ContextPicker.tsx
+++ b/src/components/ContextPicker.tsx
@@ -1,0 +1,125 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+import { CONTEXT_SOURCES } from "../context/sources/index";
+import type { ContextChip, ContextSourceItem, ContextSource } from "../context/types";
+
+interface PickerItem extends ContextSourceItem {
+  sourceType: string;
+  icon: string;
+  source: ContextSource;
+}
+
+/** Maximum number of result rows shown at once. */
+const MAX_ITEMS = 5;
+
+/**
+ * Unified fuzzy picker for all context sources.
+ *
+ * Renders a search bar followed by merged results from every registered
+ * ContextSource. The user types to filter, navigates with arrow keys,
+ * and confirms with Enter. Escape or Backspace on an empty query cancels.
+ */
+export function ContextPicker({
+  repoPath,
+  onSelect,
+  onCancel,
+}: {
+  repoPath: string;
+  onSelect: (chip: ContextChip) => void;
+  onCancel: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [items, setItems] = useState<PickerItem[]>([]);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all(
+      CONTEXT_SOURCES.map((source) =>
+        source
+          .search(query, repoPath)
+          .then((results): PickerItem[] =>
+            results.map((item) => ({ ...item, sourceType: source.type, icon: source.icon, source }))
+          )
+          .catch((): PickerItem[] => [])
+      )
+    ).then((groups) => {
+      if (cancelled) return;
+      setItems(groups.flat());
+      setSelectedIdx(0);
+    });
+
+    return () => { cancelled = true; };
+  }, [query, repoPath]);
+
+  useInput((input, key) => {
+    if (key.escape || (key.ctrl && input === "c")) {
+      onCancel();
+      return;
+    }
+
+    if (key.return) {
+      const item = items[selectedIdx];
+      if (item) onSelect(item.source.toChip(item));
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIdx((prev) => Math.max(prev - 1, 0));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIdx((prev) => Math.min(prev + 1, Math.max(items.length - 1, 0)));
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      if (query.length === 0) {
+        onCancel();
+      } else {
+        setQuery((prev) => prev.slice(0, -1));
+      }
+      return;
+    }
+
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((prev) => prev + input);
+    }
+  });
+
+  const visibleItems = items.slice(0, MAX_ITEMS);
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      {/* Search bar */}
+      <Box gap={1}>
+        <Text color="cyan">@</Text>
+        <Text>
+          {query}
+          <Text inverse> </Text>
+        </Text>
+      </Box>
+
+      {/* Results */}
+      {visibleItems.length === 0 && query.length > 0 ? (
+        <Box paddingLeft={2}>
+          <Text dimColor>no matches</Text>
+        </Box>
+      ) : (
+        visibleItems.map((item, i) => (
+          <Box key={`${item.sourceType}-${item.id}`} paddingLeft={2} gap={1}>
+            <Text
+              color={i === selectedIdx ? "cyan" : undefined}
+              inverse={i === selectedIdx}
+            >
+              {item.icon}  {item.label}
+            </Text>
+            {item.sublabel && <Text dimColor>{item.sublabel}</Text>}
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -29,11 +29,17 @@ export function PromptInput({
   placeholder = "",
   isDisabled = false,
   onSubmit,
+  onAtPrefix,
+  onBackspaceOnEmpty,
 }: {
   defaultValue?: string;
   placeholder?: string;
   isDisabled?: boolean;
   onSubmit?: (value: string) => void;
+  /** Called when '@' is typed as the first character of an empty input. */
+  onAtPrefix?: () => void;
+  /** Called when Backspace is pressed and the input is already empty. */
+  onBackspaceOnEmpty?: () => void;
 }) {
   const [value, setValue] = useState(defaultValue);
   const [cursorOffset, setCursorOffset] = useState(defaultValue.length);
@@ -125,7 +131,9 @@ export function PromptInput({
         setCursorOffset(newCursor);
       } else if (key.backspace || key.delete) {
         const cur = cursorOffsetRef.current;
-        if (cur > 0) {
+        if (cur === 0) {
+          onBackspaceOnEmpty?.();
+        } else {
           const val = valueRef.current;
           const blocks = pasteBlocksRef.current;
           // If the cursor is inside (or at the end of) a paste block, delete the whole block.
@@ -162,6 +170,12 @@ export function PromptInput({
         // strip bracketed paste markers (\x1b[200~ ... \x1b[201~).
         let cleaned = input.replace(/\[\?\d+u/g, "");
         if (!cleaned) return;
+
+        // '@' typed as the first character of an empty input triggers the context picker.
+        if (cleaned === "@" && valueRef.current.length === 0) {
+          onAtPrefix?.();
+          return;
+        }
 
         let isBracketedPaste = false;
         let pasteStartIdx = cleaned.indexOf(PASTE_START);

--- a/src/context/resolve.ts
+++ b/src/context/resolve.ts
@@ -1,0 +1,13 @@
+import type { ContextChip } from "./types";
+
+/**
+ * Translate a set of context chips into agent run option overrides.
+ * Each chip type maps to a specific field — unrecognised types are ignored.
+ */
+export function resolveChips(chips: ContextChip[]): { baseBranch?: string } {
+  const branch = chips.find((c) => c.type === "branch");
+  return {
+    baseBranch: branch?.value,
+    // future: pr/issue chips → inject context into system prompt, etc.
+  };
+}

--- a/src/context/sources/branch.ts
+++ b/src/context/sources/branch.ts
@@ -1,0 +1,37 @@
+import { fuzzyMatch } from "../../fuzzy";
+import type { ContextSource, ContextSourceItem, ContextChip } from "../types";
+
+export const branchSource: ContextSource = {
+  type: "branch",
+  label: "Branch",
+  icon: "⎇",
+
+  async search(query: string, repoPath: string): Promise<ContextSourceItem[]> {
+    const result = await Bun.$`git -C ${repoPath} branch --all --format=%(refname:short)`
+      .quiet()
+      .nothrow();
+    if (result.exitCode !== 0) return [];
+
+    const seen = new Set<string>();
+    const branches = result.stdout
+      .toString()
+      .split("\n")
+      .map((b) => b.trim().replace(/^origin\//, ""))
+      .filter((b) => {
+        if (!b || b.includes("HEAD") || b.includes("->")) return false;
+        if (seen.has(b)) return false;
+        seen.add(b);
+        return true;
+      });
+
+    const filtered = query.length > 0
+      ? branches.filter((b) => fuzzyMatch(b, query))
+      : branches;
+
+    return filtered.map((b) => ({ id: b, label: b }));
+  },
+
+  toChip(item: ContextSourceItem): ContextChip {
+    return { type: "branch", label: item.label, value: item.id };
+  },
+};

--- a/src/context/sources/index.ts
+++ b/src/context/sources/index.ts
@@ -1,0 +1,11 @@
+import { branchSource } from "./branch";
+import type { ContextSource } from "../types";
+
+/**
+ * Registry of all available context sources for the @ picker.
+ * Add new sources here to include them in the unified fuzzy search.
+ */
+export const CONTEXT_SOURCES: ContextSource[] = [
+  branchSource,
+  // future: prSource, issueSource, fileSource, ...
+];

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,0 +1,47 @@
+// ── Context system types ──────────────────────────────────────────────
+//
+// The @ context picker fans out to all registered ContextSources,
+// merges their results, and lets the user fuzzy-search across all of
+// them in one step. Selecting an item produces a ContextChip that sits
+// above the prompt input and is resolved to agent run parameters at
+// submit time.
+
+export interface ContextSourceItem {
+  id: string;
+  /** Primary display text shown in the picker list */
+  label: string;
+  /** Optional secondary info shown dimmed beside the label (e.g. last commit) */
+  sublabel?: string;
+}
+
+export interface ContextSource {
+  /** Unique type key, e.g. "branch", "pr", "issue" */
+  type: string;
+  /** Short name for display, e.g. "Branch", "Pull Request" */
+  label: string;
+  /**
+   * Icon prefix shown in picker rows and chips.
+   * @example "⎇"
+   */
+  icon: string;
+  /**
+   * Fetch items matching `query` from this source.
+   * An empty query should return a sensible default set (e.g. all local branches).
+   *
+   * @param query - The user's current search string
+   * @param repoPath - Absolute path to the git repository root
+   */
+  search(query: string, repoPath: string): Promise<ContextSourceItem[]>;
+  /** Convert a selected picker item into a chip */
+  toChip(item: ContextSourceItem): ContextChip;
+}
+
+/**
+ * A resolved context chip displayed above the prompt input.
+ * Add new members to this union to support additional context types.
+ */
+export type ContextChip =
+  | { type: "branch"; label: string; value: string };
+  // future:
+  // | { type: "pr";    label: string; value: string; url: string }
+  // | { type: "issue"; label: string; value: string; url: string }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -5,6 +5,10 @@ import { loadConfig } from "./config";
 import type { DeerConfig } from "./config";
 import { ShortcutsBar } from "./components/ShortcutsBar";
 import { LogDetailPanel } from "./components/LogDetailPanel";
+import { ContextPicker } from "./components/ContextPicker";
+import { ContextChipBar } from "./components/ContextChipBar";
+import { resolveChips } from "./context/resolve";
+import type { ContextChip } from "./context/types";
 import { runPreflight, type PreflightResult } from "./preflight";
 import { PromptInput } from "./components/PromptInput";
 import { useAgentSync } from "./hooks/useAgentSync";
@@ -39,6 +43,8 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
   const termHeight = stdout?.rows || 24;
 
   const [suspended, setSuspended] = useState(false);
+  const [contextChips, setContextChips] = useState<ContextChip[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [preflight, setPreflight] = useState<PreflightResult | null>(
     mockAgents ? { ok: true, errors: [], credentialType: "subscription" } : null,
   );
@@ -82,6 +88,7 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
     searchMatches,
   } = useKeyboardInput({
     suspended,
+    pickerOpen,
     agents,
     setAgents,
     logExpanded,
@@ -171,7 +178,10 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
   const selected = agents[clampedIdx] || null;
   const preflightOk = preflight?.ok ?? false;
 
-  const chromeHeight = 8;
+  // Base chrome: header(1) + 2 separators(2) + input(1) + shortcuts(3) = 8.
+  // Add picker height (query bar + up to 5 results) or chip bar (1 line) when visible.
+  const contextChrome = pickerOpen ? 7 : contextChips.length > 0 ? 1 : 0;
+  const chromeHeight = 8 + contextChrome;
   const detailHeight = logExpanded && selected ? Math.min(MAX_VISIBLE_LOGS + 1, 6) : 0;
   const listHeight = Math.max(termHeight - chromeHeight - detailHeight, 3);
   const hasPrEntries = agents.some((a) => a.result?.prUrl);
@@ -299,8 +309,19 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
         />
       )}
 
-      {/* Input divider + input bar */}
+      {/* Input divider + context picker/chips + input bar */}
       <Text>{"─".repeat(termWidth)}</Text>
+      {pickerOpen && (
+        <ContextPicker
+          repoPath={cwd}
+          onSelect={(chip) => {
+            setContextChips((prev) => [...prev, chip]);
+            setPickerOpen(false);
+          }}
+          onCancel={() => setPickerOpen(false)}
+        />
+      )}
+      {!pickerOpen && <ContextChipBar chips={contextChips} />}
       <Box paddingX={1} gap={1}>
         {searchMode ? (
           <>
@@ -325,12 +346,16 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
               <PromptInput
                 key={inputKey}
                 placeholder={!preflightOk ? t("input_preflight_failed") : t("input_placeholder")}
-                isDisabled={!preflightOk}
+                isDisabled={!preflightOk || pickerOpen}
                 defaultValue={inputDefault}
+                onAtPrefix={() => setPickerOpen(true)}
+                onBackspaceOnEmpty={() => setContextChips((prev) => prev.slice(0, -1))}
                 onSubmit={(value) => {
                   if (value.trim()) {
                     addToHistory(value);
-                    spawnAgent(value);
+                    const { baseBranch } = resolveChips(contextChips);
+                    spawnAgent(value, baseBranch);
+                    setContextChips([]);
                   }
                 }}
               />

--- a/src/hooks/useKeyboardInput.ts
+++ b/src/hooks/useKeyboardInput.ts
@@ -8,6 +8,8 @@ import { openUrl, isActive } from "../dashboard-utils";
 
 interface KeyboardInputDeps {
   suspended: boolean;
+  /** When the context picker is open, all keyboard handling is suspended so the picker owns input. */
+  pickerOpen: boolean;
   agents: AgentState[];
   setAgents: Dispatch<SetStateAction<AgentState[]>>;
   logExpanded: boolean;
@@ -41,6 +43,7 @@ function copyLogsToClipboard(agent: AgentState): void {
 
 export function useKeyboardInput({
   suspended,
+  pickerOpen,
   agents,
   setAgents: _setAgents,
   logExpanded,
@@ -258,7 +261,7 @@ export function useKeyboardInput({
   // ── Main input handler ────────────────────────────────────────────
 
   useInput((input, key) => {
-    if (suspended) return;
+    if (suspended || pickerOpen) return;
 
     if (handleSearchInput(input, key)) return;
     if (handleQuitInput(input)) return;


### PR DESCRIPTION
## Task

> Difficult to add fix on an existing branch. Each task always creates a new worktree and branch. There is no way to add fixes to an existing branch (e.g. to fix a CI failure on a PR the agent already created). Propose mechanisms we could use to allow users to start a task from a given branch while not disturbing the main ux too much.

## Summary

Introduces an `@` context picker that lets users attach a branch chip to their prompt before submitting. Typing `@` in an empty prompt opens a fuzzy search over all local and remote git branches. The selected branch is passed to `spawnAgent` as `baseBranch`, allowing tasks to run on an existing branch rather than always creating a new one. The picker is dismissible with Escape or Backspace and sits between the divider and the prompt input so it does not disrupt the core dashboard layout.

## Changes

- `src/context/types.ts` — defines `ContextSource`, `ContextSourceItem`, and `ContextChip` types that model the extensible picker system
- `src/context/sources/branch.ts` — `branchSource` implementation that shells out to `git branch --all` and fuzzy-filters results
- `src/context/sources/index.ts` — `CONTEXT_SOURCES` registry; new sources can be added here
- `src/context/resolve.ts` — `resolveChips` translates selected chips into agent run option overrides (e.g. `baseBranch`)
- `src/components/ContextPicker.tsx` — unified fuzzy picker UI component; fans out to all registered sources and handles its own keyboard input
- `src/components/ContextChipBar.tsx` — renders selected context chips above the prompt input
- `src/components/PromptInput.tsx` — adds `onAtPrefix` (fires when `@` is typed into an empty input) and `onBackspaceOnEmpty` callbacks
- `src/dashboard.tsx` — wires picker open/close state, chip state, chrome height adjustment, and passes `baseBranch` to `spawnAgent` on submit
- `src/hooks/useKeyboardInput.ts` — suspends global keyboard handling while the picker is open so the picker owns input exclusively

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.