### PR TITLE
🦌 Fix branch picker not matching branches with @ query

### DIFF
--- a/src/context/sources/branch.ts
+++ b/src/context/sources/branch.ts
@@ -7,7 +7,8 @@ export const branchSource: ContextSource = {
   icon: "⎇",
 
   async search(query: string, repoPath: string): Promise<ContextSourceItem[]> {
-    const result = await Bun.$`git -C ${repoPath} branch --all --format=%(refname:short)`
+    const fmt = "%(refname:short)";
+    const result = await Bun.$`git -C ${repoPath} branch --all --format=${fmt}`
       .quiet()
       .nothrow();
     if (result.exitCode !== 0) return [];


### PR DESCRIPTION
## Task

> typing @ and 'deer' does not list any branches in the picker even though we have many branches with that prefix

## Summary

The branch picker returned no results when querying for branches with certain prefixes (e.g. `deer`). The root cause was that the `--format` flag value `%(refname:short)` was being passed directly as a template literal interpolation, which caused the `%` characters to be interpreted or escaped incorrectly by the shell, resulting in git receiving a malformed format string and outputting nothing useful.

Fixing this by extracting the format string into a variable before interpolation ensures Bun's shell passes it as a plain string argument without misinterpreting the `%` sigils.

## Changes

- `src/context/sources/branch.ts`: Extract `%(refname:short)` format string into a local variable before shell interpolation to prevent `%` characters from being mangled

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.