### PR TITLE
🦌 Fix tmux detach exiting outer session when nested

### DIFF
--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -332,6 +332,9 @@ export function useAgentActions({
     if (process.env.TMUX) {
       // Already inside tmux — switch-client is non-blocking; deer keeps running.
       const { spawnSync } = await import("node:child_process");
+      // Rebind prefix-d to switch-client -l so Ctrl+b d returns to the previous
+      // (deer) session instead of detaching from the tmux server entirely.
+      spawnSync("tmux", ["bind-key", "d", "switch-client", "-l"], { stdio: "inherit" });
       spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
     } else {
       await withSuspendedTerminal(setSuspended, async () => {
@@ -373,6 +376,9 @@ export function useAgentActions({
 
     if (process.env.TMUX) {
       // Already inside tmux — switch-client is non-blocking; deer keeps running.
+      // Rebind prefix-d to switch-client -l so Ctrl+b d returns to the previous
+      // (deer) session instead of detaching from the tmux server entirely.
+      spawnSync("tmux", ["bind-key", "d", "switch-client", "-l"], { stdio: "inherit" });
       spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
     } else {
       await withSuspendedTerminal(setSuspended, async () => {


### PR DESCRIPTION
## Task

> tmux-in-tmux now works, but when we detach, it detaches from both the inner tmux and the outer one also.

## Summary

When running deer inside an existing tmux session and switching to an agent session, pressing the detach key (`prefix-d`) would detach from the tmux server entirely rather than returning to the deer session. This fix rebinds `d` (the detach key) to `switch-client -l` before switching, so the user is returned to the previous (deer) session instead of fully detaching.

## Changes

- `src/hooks/useAgentActions.ts`: Before switching to an agent tmux session, rebind `prefix-d` to `switch-client -l` so detaching returns to the deer session rather than exiting tmux entirely.

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.