### PR TITLE
🦌 Keep event loop alive during tmux attach for background tasks

### DIFF
--- a/src/dashboard-utils.ts
+++ b/src/dashboard-utils.ts
@@ -81,8 +81,8 @@ export function captureSnapshot(lines: string[]): string {
 
 /**
  * Synchronous flag indicating the terminal is suspended for a child process
- * (e.g. tmux attach). Checked by input handlers that can't rely on React
- * state updates (which are async and blocked during spawnSync).
+ * (e.g. tmux attach). Checked by input handlers that need an immediate
+ * synchronous check rather than waiting for async React state updates.
  */
 export let terminalSuspended = false;
 

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -338,8 +338,13 @@ export function useAgentActions({
         // Small delay to let any pending keypress (e.g. the Enter that triggered
         // attach) flush through before tmux takes over stdin.
         await Bun.sleep(50);
-        const { spawnSync } = await import("node:child_process");
-        spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
+        // Use async Bun.spawn so the event loop stays alive during attachment,
+        // allowing background work (e.g. PR creation) to continue unblocked.
+        await Bun.spawn(["tmux", "attach", "-t", sessionName], {
+          stdin: "inherit",
+          stdout: "inherit",
+          stderr: "inherit",
+        }).exited;
       });
     }
 
@@ -377,7 +382,13 @@ export function useAgentActions({
     } else {
       await withSuspendedTerminal(setSuspended, async () => {
         await Bun.sleep(50);
-        spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
+        // Use async Bun.spawn so the event loop stays alive during attachment,
+        // allowing background work (e.g. PR creation) to continue unblocked.
+        await Bun.spawn(["tmux", "attach", "-t", sessionName], {
+          stdin: "inherit",
+          stdout: "inherit",
+          stderr: "inherit",
+        }).exited;
       });
     }
   }, [setSuspended]);


### PR DESCRIPTION
## Task

> does PR creation only run while we are in the TUI? it seems like if we attach while PR creation is in progress, it wont complete until we detach. PR creation should be a background process.

## Summary

`spawnSync` blocks the Node.js/Bun event loop entirely while attached to a tmux session, preventing any background work (such as PR creation) from making progress until the user detaches. Switching to async `Bun.spawn` keeps the event loop alive during attachment, so background tasks continue running uninterrupted.

## Changes

- `src/hooks/useAgentActions.ts`: Replaced both `spawnSync("tmux", ["attach", ...])` calls with `await Bun.spawn(["tmux", "attach", ...]).exited` so the event loop is not blocked during tmux attachment
- `src/dashboard-utils.ts`: Updated `terminalSuspended` comment to accurately describe its purpose without referencing the old `spawnSync` behaviour

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.