### PR TITLE
🦌 Fix context picker selection scrolling off screen

### DIFF
--- a/src/components/ContextPicker.tsx
+++ b/src/components/ContextPicker.tsx
@@ -31,6 +31,7 @@ export function ContextPicker({
   const [query, setQuery] = useState("");
   const [items, setItems] = useState<PickerItem[]>([]);
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -48,6 +49,7 @@ export function ContextPicker({
       if (cancelled) return;
       setItems(groups.flat());
       setSelectedIdx(0);
+      setScrollOffset(0);
     });
 
     return () => { cancelled = true; };
@@ -66,12 +68,20 @@ export function ContextPicker({
     }
 
     if (key.upArrow) {
-      setSelectedIdx((prev) => Math.max(prev - 1, 0));
+      setSelectedIdx((prev) => {
+        const next = Math.max(prev - 1, 0);
+        setScrollOffset((off) => Math.min(off, next));
+        return next;
+      });
       return;
     }
 
     if (key.downArrow) {
-      setSelectedIdx((prev) => Math.min(prev + 1, Math.max(items.length - 1, 0)));
+      setSelectedIdx((prev) => {
+        const next = Math.min(prev + 1, Math.max(items.length - 1, 0));
+        setScrollOffset((off) => Math.max(off, next - MAX_ITEMS + 1));
+        return next;
+      });
       return;
     }
 
@@ -89,7 +99,7 @@ export function ContextPicker({
     }
   });
 
-  const visibleItems = items.slice(0, MAX_ITEMS);
+  const visibleItems = items.slice(scrollOffset, scrollOffset + MAX_ITEMS);
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -111,8 +121,8 @@ export function ContextPicker({
         visibleItems.map((item, i) => (
           <Box key={`${item.sourceType}-${item.id}`} paddingLeft={2} gap={1}>
             <Text
-              color={i === selectedIdx ? "cyan" : undefined}
-              inverse={i === selectedIdx}
+              color={i + scrollOffset === selectedIdx ? "cyan" : undefined}
+              inverse={i + scrollOffset === selectedIdx}
             >
               {item.icon}  {item.label}
             </Text>


### PR DESCRIPTION
## Task

> when we use the branch picker, if we use arrow keys to scroll down, our selection goes 'off the bottom of the page', so we cant see it

## Summary

The context picker was slicing items from the beginning of the list regardless of selection position, causing the selected item to scroll out of view when navigating past the visible window. A `scrollOffset` state was added to track the viewport position and keep the selected item visible.

## Changes

- `src/components/ContextPicker.tsx`: Added `scrollOffset` state to track the visible window start index
- Updated up/down arrow handlers to adjust `scrollOffset` so the selection stays within the visible window
- Changed `visibleItems` slice to use `scrollOffset` as the start index instead of always starting from 0
- Updated item highlight logic to compare `i + scrollOffset === selectedIdx` instead of `i === selectedIdx`

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.