### PR TITLE
🦌 Fix re-attach when tmux session outlives a closed deer instance

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -132,6 +132,30 @@ export function liveTaskFromStateFile(stateFile: TaskStateFile): AgentState {
 }
 
 /**
+ * Build a running AgentState from a JSONL history entry whose tmux session
+ * survived after deer closed. Used when there is no live state.json but the
+ * tmux session is confirmed alive, so the task can be resumed.
+ */
+export function liveAgentFromHistory(task: PersistedTask): AgentState {
+  return createAgentState({
+    taskId: task.taskId,
+    prompt: task.prompt,
+    baseBranch: task.baseBranch || "main",
+    status: "running",
+    elapsed: task.elapsed,
+    lastActivity: task.lastActivity,
+    result: task.finalBranch
+      ? { finalBranch: task.finalBranch, prUrl: task.prUrl ?? "" }
+      : null,
+    createdAt: task.createdAt,
+    worktreePath: task.worktreePath || "",
+    branch: task.finalBranch ?? `deer/${task.taskId}`,
+    cost: task.cost ?? null,
+    historical: true,
+  });
+}
+
+/**
  * Build an AgentState from a state file whose owning process has died.
  * Shows the task as interrupted with its last known state.
  * If the task was idle (Claude had finished), the idle flag is preserved so

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -7,7 +7,7 @@ import type { SandboxCleanup } from "../sandbox/index";
 import { isTmuxSessionDead } from "../sandbox/index";
 import { resolveRuntime } from "../sandbox/resolve";
 import { detectRepo } from "../git/worktree";
-import { type AgentState, historicalAgent, liveTaskFromStateFile, historicalAgentFromStateFile } from "../agent-state";
+import { type AgentState, historicalAgent, liveAgentFromHistory, liveTaskFromStateFile, historicalAgentFromStateFile } from "../agent-state";
 import { readTaskState, scanLiveTaskIds, isOwnerAlive } from "../task-state";
 import type { DeerConfig } from "../config";
 import { TASK_SYNC_DEBOUNCE_MS, TASK_SYNC_SAFETY_POLL_MS } from "../constants";
@@ -127,6 +127,17 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       // No state.json — fall back to JSONL history entry
       const fileTask = fileTasks.find(t => t.taskId === taskId);
       if (fileTask) {
+        // If the task was saved as "running" (deer closed while it was active),
+        // check whether the tmux session survived before showing as interrupted.
+        if (fileTask.status === "running" && !liveSessionIdsRef.current.has(taskId)) {
+          const sessionDead = await isTmuxSessionDead(`deer-${taskId}`);
+          if (!sessionDead) {
+            liveSessionIdsRef.current.add(taskId);
+            // Show as running while we hand off to the poll loop
+            newAgents.push(liveAgentFromHistory(fileTask));
+            continue;
+          }
+        }
         newAgents.push(historicalAgent(fileTask));
       }
     }

--- a/test/e2e/state-sync.test.ts
+++ b/test/e2e/state-sync.test.ts
@@ -30,6 +30,7 @@ import {
   liveTaskFromStateFile,
   historicalAgentFromStateFile,
   historicalAgent,
+  liveAgentFromHistory,
 } from "../../src/agent-state";
 
 const e2e = process.env.DEER_E2E ? describe : describe.skip;
@@ -225,6 +226,16 @@ e2e("JSONL history", () => {
 
     expect(agent.status).toBe("interrupted");
     expect(agent.lastActivity).toBe("Interrupted — deer was closed");
+  });
+
+  test("liveAgentFromHistory builds a running historical agent from a persisted task", async () => {
+    const task = makePersistedTask({ status: "running", lastActivity: "● Doing work" });
+    const agent = liveAgentFromHistory(task);
+
+    expect(agent.status).toBe("running");
+    expect(agent.historical).toBe(true);
+    expect(agent.lastActivity).toBe("● Doing work");
+    expect(agent.taskId).toBe(task.taskId);
   });
 
   test("removeFromHistory removes the task from loadHistory results", async () => {


### PR DESCRIPTION
## Task

> if we launch a second deer instance, and a task was started in the first instance, when we detach, the task in the second deer instance will show with a '!', and we cant re-attach to the instance

## Summary

When deer closed while a task was running, the tmux session could survive but the second deer instance had no `state.json` to read — so it fell back to marking the task as interrupted (`!`), making re-attach impossible.

The fix adds a `liveAgentFromHistory` helper that reconstructs a `running` `AgentState` from a JSONL history entry. During sync, if a history entry is `running` and the corresponding tmux session is still alive, the task is shown as running (not interrupted) and handed off to the normal poll loop so the user can re-attach.

## Changes

- `src/agent-state.ts`: Added `liveAgentFromHistory` — builds a running `AgentState` from a `PersistedTask` when no live `state.json` exists but the tmux session is confirmed alive.
- `src/hooks/useAgentSync.ts`: In the no-`state.json` fallback path, check whether a `running` history entry's tmux session is still alive before marking it as interrupted; if alive, emit a live agent and continue.
- `test/e2e/state-sync.test.ts`: Added test covering `liveAgentFromHistory` output shape.

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.