### PR TITLE
🦌 Enforce per-type chip limit with LIFO eviction

### DIFF
--- a/src/context/sources/branch.ts
+++ b/src/context/sources/branch.ts
@@ -5,6 +5,7 @@ export const branchSource: ContextSource = {
   type: "branch",
   label: "Branch",
   icon: "⎇",
+  limit: 1,
 
   async search(query: string, repoPath: string): Promise<ContextSourceItem[]> {
     const fmt = "%(refname:short)";

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -25,6 +25,12 @@ export interface ContextSource {
    */
   icon: string;
   /**
+   * Maximum number of chips of this type that can be active at once.
+   * When the limit is reached, adding a new chip displaces the most recently
+   * added chip of this type (LIFO). Omit for no limit.
+   */
+  limit?: number;
+  /**
    * Fetch items matching `query` from this source.
    * An empty query should return a sensible default set (e.g. all local branches).
    *

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -8,6 +8,7 @@ import { LogDetailPanel } from "./components/LogDetailPanel";
 import { ContextPicker } from "./components/ContextPicker";
 import { ContextChipBar } from "./components/ContextChipBar";
 import { resolveChips } from "./context/resolve";
+import { CONTEXT_SOURCES } from "./context/sources/index";
 import type { ContextChip } from "./context/types";
 import { runPreflight, type PreflightResult } from "./preflight";
 import { PromptInput } from "./components/PromptInput";
@@ -315,7 +316,19 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
         <ContextPicker
           repoPath={cwd}
           onSelect={(chip) => {
-            setContextChips((prev) => [...prev, chip]);
+            const limit = CONTEXT_SOURCES.find((s) => s.type === chip.type)?.limit;
+            setContextChips((prev) => {
+              if (limit === undefined || prev.filter((c) => c.type === chip.type).length < limit) {
+                return [...prev, chip];
+              }
+              // Limit reached: remove the last chip of this type (LIFO), append the new one
+              let evicted = false;
+              const next = prev.reduceRight<ContextChip[]>((acc, c) => {
+                if (!evicted && c.type === chip.type) { evicted = true; return acc; }
+                return [c, ...acc];
+              }, []);
+              return [...next, chip];
+            });
             setPickerOpen(false);
           }}
           onCancel={() => setPickerOpen(false)}


### PR DESCRIPTION
## Task

> what happens if the user selects two branches for context? currently its allowed. We want to have each token type set a limit of how many of those chips can be set, (optional), which, when set, have a 'last in first out' override approach, so if we have a limit of 3 chips of some type, then adding 4th would overwrite the 3rd. Using this approach, branch would have limit 1

## Summary

Adds an optional `limit` field to `ContextSource` that caps how many chips of a given type can be active simultaneously. When the limit is reached, adding a new chip evicts the most recently added chip of that type (LIFO), keeping the list size bounded. Branch sources are given a limit of 1, preventing multiple branches from being selected at once.

## Changes

- `src/context/types.ts`: Added optional `limit?: number` field to the `ContextSource` interface with JSDoc describing the LIFO eviction behavior
- `src/context/sources/branch.ts`: Set `limit: 1` on the branch source so only one branch chip can be active at a time
- `src/dashboard.tsx`: Updated the `onSelect` handler in `ContextPicker` to enforce per-type limits using LIFO eviction — if the limit is not yet reached the chip is appended normally; if reached, the last chip of that type is removed before the new one is added

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.