### PR TITLE
🦌 Show '@' shortcut hint in ShortcutsBar when input is focused and empty

### DIFF
--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -31,6 +31,7 @@ export function PromptInput({
   onSubmit,
   onAtPrefix,
   onBackspaceOnEmpty,
+  onChange,
 }: {
   defaultValue?: string;
   placeholder?: string;
@@ -40,6 +41,8 @@ export function PromptInput({
   onAtPrefix?: () => void;
   /** Called when Backspace is pressed and the input is already empty. */
   onBackspaceOnEmpty?: () => void;
+  /** Called whenever the input value changes. */
+  onChange?: (value: string) => void;
 }) {
   const [value, setValue] = useState(defaultValue);
   const [cursorOffset, setCursorOffset] = useState(defaultValue.length);
@@ -53,6 +56,10 @@ export function PromptInput({
   valueRef.current = value;
   cursorOffsetRef.current = cursorOffset;
   pasteBlocksRef.current = pasteBlocks;
+
+  useEffect(() => {
+    onChange?.(value);
+  }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Enable bracketed paste mode so the terminal wraps pasted text in
   // \x1b[200~ ... \x1b[201~ markers, delivering it as a single input event.

--- a/src/components/ShortcutsBar.tsx
+++ b/src/components/ShortcutsBar.tsx
@@ -9,6 +9,7 @@ import { t, type StringKey } from "../i18n";
 interface ShortcutsBarProps {
   selected: AgentState | null;
   inputFocused: boolean;
+  inputEmpty: boolean;
   searchMode: boolean;
   verboseMode: boolean;
   logExpanded: boolean;
@@ -19,6 +20,7 @@ interface ShortcutsBarProps {
 export function ShortcutsBar({
   selected,
   inputFocused,
+  inputEmpty,
   searchMode,
   verboseMode,
   logExpanded,
@@ -100,6 +102,9 @@ export function ShortcutsBar({
         ) : (
           <>
             <Text><Text bold color="white">Tab</Text><Text dimColor> {t("shortcuts_focus")}</Text></Text>
+            {inputFocused && inputEmpty && (
+              <Text><Text bold color="white">@</Text><Text dimColor> context</Text></Text>
+            )}
             {!inputFocused && (
               <>
                 <Text><Text bold color="white">j/k</Text><Text dimColor> {t("shortcuts_nav")}</Text></Text>

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -46,6 +46,7 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
   const [suspended, setSuspended] = useState(false);
   const [contextChips, setContextChips] = useState<ContextChip[]>([]);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [inputEmpty, setInputEmpty] = useState(true);
   const [preflight, setPreflight] = useState<PreflightResult | null>(
     mockAgents ? { ok: true, errors: [], credentialType: "subscription" } : null,
   );
@@ -363,12 +364,14 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
                 defaultValue={inputDefault}
                 onAtPrefix={() => setPickerOpen(true)}
                 onBackspaceOnEmpty={() => setContextChips((prev) => prev.slice(0, -1))}
+                onChange={(v) => setInputEmpty(v.length === 0)}
                 onSubmit={(value) => {
                   if (value.trim()) {
                     addToHistory(value);
                     const { baseBranch } = resolveChips(contextChips);
                     spawnAgent(value, baseBranch);
                     setContextChips([]);
+                    setInputEmpty(true);
                   }
                 }}
               />
@@ -384,6 +387,7 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
       <ShortcutsBar
         selected={selected}
         inputFocused={inputFocused}
+        inputEmpty={inputEmpty}
         searchMode={searchMode}
         verboseMode={verboseMode}
         logExpanded={logExpanded}


### PR DESCRIPTION
## Task

> add '@' shortcut legend when promptinput is focused to show that user can add context, it should only show when there is no text in the promptinput, as @ doesnt work if its not at the start

## Summary

Adds a contextual `@` shortcut hint to the shortcuts bar that appears only when the prompt input is focused and empty. Since `@` only triggers context selection at the start of input, the hint is hidden once the user starts typing.

## Changes

- `src/components/PromptInput.tsx`: Added `onChange` prop that fires whenever the input value changes, allowing parent components to track input state
- `src/components/ShortcutsBar.tsx`: Added `inputEmpty` prop and conditionally renders `@ context` shortcut hint when input is both focused and empty
- `src/dashboard.tsx`: Added `inputEmpty` state, wires `onChange` to update it, resets it to `true` on submit, and passes it to `ShortcutsBar`

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.