### PR TITLE
🦌 Fix tmux detach to return to TUI instead of outer session

### DIFF
--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -332,10 +332,11 @@ export function useAgentActions({
     if (process.env.TMUX) {
       // Already inside tmux — switch-client is non-blocking; deer keeps running.
       const { spawnSync } = await import("node:child_process");
-      // Rebind prefix-d to switch-client -l so Ctrl+b d returns to the previous
-      // (deer) session instead of detaching from the tmux server entirely.
-      // Chaining bind-key d detach-client restores the default when switching back.
-      spawnSync("tmux", ["bind-key", "d", "switch-client", "-l", ";", "bind-key", "d", "detach-client"], { stdio: "inherit" });
+      // Rebind prefix-d to a command block: switch back to the deer session,
+      // then immediately restore d to detach-client so the next Ctrl+b d in
+      // the deer session detaches normally. The {} block runs as a single
+      // binding (tmux 3.2+), unlike ; which is a top-level command separator.
+      spawnSync("tmux", ["bind-key", "d", "{", "switch-client", "-l", ";", "bind-key", "d", "detach-client", "}"], { stdio: "inherit" });
       spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
     } else {
       await withSuspendedTerminal(setSuspended, async () => {
@@ -377,10 +378,11 @@ export function useAgentActions({
 
     if (process.env.TMUX) {
       // Already inside tmux — switch-client is non-blocking; deer keeps running.
-      // Rebind prefix-d to switch-client -l so Ctrl+b d returns to the previous
-      // (deer) session instead of detaching from the tmux server entirely.
-      // Chaining bind-key d detach-client restores the default when switching back.
-      spawnSync("tmux", ["bind-key", "d", "switch-client", "-l", ";", "bind-key", "d", "detach-client"], { stdio: "inherit" });
+      // Rebind prefix-d to a command block: switch back to the deer session,
+      // then immediately restore d to detach-client so the next Ctrl+b d in
+      // the deer session detaches normally. The {} block runs as a single
+      // binding (tmux 3.2+), unlike ; which is a top-level command separator.
+      spawnSync("tmux", ["bind-key", "d", "{", "switch-client", "-l", ";", "bind-key", "d", "detach-client", "}"], { stdio: "inherit" });
       spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
     } else {
       await withSuspendedTerminal(setSuspended, async () => {


### PR DESCRIPTION
## Task

> now, when we detach from tmux-in-tmux, the outer tmux detaches. Our goal is that when controlling the inner tmux, detaching just goes back to the TUI (within parent tmux), and then the user can detach the parent tmux again to detach fully from tmux

## Summary

When running deer inside tmux and launching an agent in a nested tmux session, pressing `Ctrl+b d` was detaching from the outer tmux server instead of returning to the deer TUI. The fix uses a tmux `{}` command block (tmux 3.2+) to atomically switch back to the deer session and restore the default `d` binding in a single keybinding, preventing the semicolon from being interpreted as a top-level command separator.

## Changes

- `src/hooks/useAgentActions.ts`: Updated both tmux `bind-key` calls to wrap the switch-client and bind-key restore commands in a `{}` block, ensuring the binding executes atomically and correctly returns focus to the deer TUI session

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.