### PR TITLE
🦌 Allow creating a new PR after previous PR is merged

### DIFF
--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -396,7 +396,8 @@ export function useAgentActions({
   // ── Create PR ─────────────────────────────────────────────────────
 
   const createPr = useCallback(async (agent: AgentState) => {
-    if (!agent.worktreePath || agent.result?.prUrl) return;
+    if (!agent.worktreePath) return;
+    if (agent.result?.prUrl && agent.prState !== "merged") return;
 
     agent.creatingPr = true;
     agent.lastActivity = t("activity_creating_pr");

--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -126,7 +126,7 @@ export function availableActions(ctx: AgentContext): AgentAction[] {
       case "attach":
         return ctx.hasHandle;
       case "create_pr":
-        return ctx.hasFinalBranch && !ctx.hasPrUrl;
+        return ctx.hasFinalBranch && (!ctx.hasPrUrl || ctx.prState === "merged");
       case "open_pr":
         return ctx.hasPrUrl;
       case "open_shell":

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -187,8 +187,41 @@ describe("availableActions", () => {
       hasPrUrl: true,
       hasFinalBranch: true,
       hasHandle: true,
+      prState: "open",
     }));
     expect(actions).toContain("open_pr");
+    expect(actions).not.toContain("create_pr");
+  });
+
+  test("create_pr available when original PR was merged and there is a final branch", () => {
+    const actions = availableActions(baseCtx({
+      status: "running",
+      isIdle: true,
+      hasPrUrl: true,
+      hasFinalBranch: true,
+      hasHandle: true,
+      prState: "merged",
+    }));
+    expect(actions).toContain("create_pr");
+  });
+
+  test("create_pr not available when PR is open (even with final branch)", () => {
+    const actions = availableActions(baseCtx({
+      isIdle: true,
+      hasPrUrl: true,
+      hasFinalBranch: true,
+      prState: "open",
+    }));
+    expect(actions).not.toContain("create_pr");
+  });
+
+  test("create_pr not available when PR is closed", () => {
+    const actions = availableActions(baseCtx({
+      isIdle: true,
+      hasPrUrl: true,
+      hasFinalBranch: true,
+      prState: "closed",
+    }));
     expect(actions).not.toContain("create_pr");
   });
 


### PR DESCRIPTION
## Task

> if a PR was already created and merged, we should be able to open another PR IF there are more changes since the original PR, this is so we can continue a previous conversation and create a new PR from it

## Summary

Previously, once a PR URL existed on an agent, the `create_pr` action was blocked regardless of the PR's state. This prevented continuing work in a conversation after a PR had been merged. The fix allows `create_pr` when the existing PR is in a `merged` state, enabling follow-up PRs from continued conversations.

## Changes

- `src/hooks/useAgentActions.ts`: Updated `createPr` guard to only block PR creation if a `prUrl` exists **and** the PR is not yet merged
- `src/state-machine.ts`: Updated `create_pr` action availability logic to permit the action when `prState === "merged"`, even if a `prUrl` already exists
- `test/state-machine.test.ts`: Added tests covering the new merged-PR behavior — `create_pr` is available after merge, unavailable when open or closed

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.