### PR TITLE
🦌 Fix shared/restored state across deer CLI instances and restarts

### DIFF
--- a/src/agent-state.ts
+++ b/src/agent-state.ts
@@ -85,14 +85,20 @@ export function createAgentState(overrides: Partial<AgentState>): AgentState {
 
 /** Convert a persisted task to a read-only AgentState for display. */
 export function historicalAgent(task: PersistedTask): AgentState {
-  const wasInterrupted = task.status === "running";
+  // status="running" with idle=true means Claude finished and deer was closed
+  // before a PR was created — restore as interrupted but preserve idle so
+  // "create PR" remains available.
+  // status="running" with idle=false means deer was closed mid-run.
+  const wasRunning = task.status === "running";
+  const wasIdle = wasRunning && !!task.idle;
   return createAgentState({
     taskId: task.taskId,
     prompt: task.prompt,
     baseBranch: task.baseBranch || "main",
-    status: wasInterrupted ? "interrupted" : (task.status as AgentStatus),
+    status: wasRunning ? "interrupted" : (task.status as AgentStatus),
+    idle: wasIdle,
     elapsed: task.elapsed,
-    lastActivity: wasInterrupted ? "Interrupted — deer was closed" : task.lastActivity,
+    lastActivity: (wasRunning && !wasIdle) ? "Interrupted — deer was closed" : task.lastActivity,
     result: task.finalBranch
       ? { finalBranch: task.finalBranch, prUrl: task.prUrl ?? "" }
       : null,
@@ -155,18 +161,27 @@ export function liveAgentFromHistory(task: PersistedTask): AgentState {
   });
 }
 
+// Statuses written to state.json that represent a graceful terminal outcome.
+// These are preserved as-is instead of being overridden with "interrupted".
+const TERMINAL_STATUSES = new Set<string>(["cancelled", "failed", "pr_failed"]);
+
 /**
  * Build an AgentState from a state file whose owning process has died.
  * Shows the task as interrupted with its last known state.
  * If the task was idle (Claude had finished), the idle flag is preserved so
  * actions like "create PR" remain available on restart.
+ * If the state file records a terminal status (cancelled/failed/pr_failed),
+ * that status is preserved rather than overriding it with "interrupted".
  */
 export function historicalAgentFromStateFile(stateFile: TaskStateFile): AgentState {
+  const status: AgentStatus = TERMINAL_STATUSES.has(stateFile.status)
+    ? (stateFile.status as AgentStatus)
+    : "interrupted";
   return createAgentState({
     taskId: stateFile.taskId,
     prompt: stateFile.prompt,
     baseBranch: stateFile.baseBranch || "main",
-    status: "interrupted",
+    status,
     elapsed: stateFile.elapsed,
     // If the agent was idle (Claude finished) before deer was closed, preserve
     // the last activity so the user can see what it was doing. Otherwise, show

--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -85,6 +85,7 @@ async function saveToHistory(agent: AgentState, repoPath: string): Promise<void>
     error: agent.error || null,
     lastActivity: agent.lastActivity,
     cost: agent.cost ?? null,
+    idle: agent.idle || undefined,
   };
   await upsertHistory(repoPath, task);
 }
@@ -282,9 +283,11 @@ export function useAgentActions({
       paneStateRef.current.delete(taskId);
       if (!agent.deleted) {
         await saveToHistory(agent, cwd);
+        // Remove the live state file — the JSONL history entry is now authoritative.
+        // Skipped when deleted=true (retryAgent reuses the taskId and will manage
+        // state.json itself, so removing it here would race the new spawn).
+        await removeTaskState(taskId).catch(() => {});
       }
-      // Remove the live state file — the JSONL history entry is now authoritative
-      await removeTaskState(taskId).catch(() => {});
       setAgents((prev) => [...prev]);
     }
   }, [cwd, preflight]);
@@ -506,7 +509,11 @@ export function useAgentActions({
     const effectiveBranch = result?.finalBranch || branch;
 
     if (worktreePath) {
-      // Kill the tmux session but preserve the worktree for --continue
+      // Kill the tmux session but preserve the worktree for --continue.
+      // Mark deleted so the old spawnAgent's finally block skips saveToHistory
+      // and removeTaskState — the new spawn reuses the same taskId and manages
+      // state.json itself.
+      agent.deleted = true;
       Bun.spawn(["tmux", "kill-session", "-t", `deer-${taskId}`], {
         stdout: "pipe", stderr: "pipe",
       }).exited.catch(() => {});
@@ -581,8 +588,8 @@ export function useAgentActions({
       paneStateRef.current.delete(agent.taskId);
       if (!agent.deleted) {
         await saveToHistory(agent, cwd);
+        await removeTaskState(agent.taskId).catch(() => {});
       }
-      await removeTaskState(agent.taskId).catch(() => {});
       setAgents((prev) => [...prev]);
     }
   }, [cwd]);

--- a/src/hooks/useAgentSync.ts
+++ b/src/hooks/useAgentSync.ts
@@ -102,6 +102,18 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
           continue;
         }
 
+        if (ownerAlive && stateFile.ownerPid === process.pid) {
+          // This instance owns the task. Keep the existing locally-managed agent
+          // as-is; if it hasn't been claimed yet (e.g. resumeLiveSession just
+          // wrote ownerPid but React hasn't re-rendered), show from state file.
+          if (existing && !existing.historical) {
+            newAgents.push(existing);
+          } else {
+            newAgents.push(liveTaskFromStateFile(stateFile));
+          }
+          continue;
+        }
+
         // Owner process died — clean up any restored proxy
         const proxyCleanup = restoredProxiesRef.current.get(taskId);
         if (proxyCleanup) {
@@ -113,8 +125,12 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
         // still running and we should resume polling instead of showing as
         // interrupted. Add to liveSessionIdsRef for the dashboard to pick up.
         const sessionDead = await isTmuxSessionDead(`deer-${taskId}`);
-        if (!sessionDead && !liveSessionIdsRef.current.has(taskId)) {
-          liveSessionIdsRef.current.add(taskId);
+        if (!sessionDead) {
+          // Always show as running while a resume is pending or in-flight.
+          // Only add to the set if not already there (i.e. first discovery).
+          if (!liveSessionIdsRef.current.has(taskId)) {
+            liveSessionIdsRef.current.add(taskId);
+          }
           // Show as running with last known state while we hand off to the poll loop
           newAgents.push(liveTaskFromStateFile(stateFile));
           continue;
@@ -129,10 +145,13 @@ export function useAgentSync(cwd: string, configRef: MutableRefObject<DeerConfig
       if (fileTask) {
         // If the task was saved as "running" (deer closed while it was active),
         // check whether the tmux session survived before showing as interrupted.
-        if (fileTask.status === "running" && !liveSessionIdsRef.current.has(taskId)) {
+        if (fileTask.status === "running") {
           const sessionDead = await isTmuxSessionDead(`deer-${taskId}`);
           if (!sessionDead) {
-            liveSessionIdsRef.current.add(taskId);
+            // Always show as running while a resume is pending or in-flight.
+            if (!liveSessionIdsRef.current.has(taskId)) {
+              liveSessionIdsRef.current.add(taskId);
+            }
             // Show as running while we hand off to the poll loop
             newAgents.push(liveAgentFromHistory(fileTask));
             continue;

--- a/src/task.ts
+++ b/src/task.ts
@@ -58,6 +58,12 @@ export interface PersistedTask extends TaskMetadata {
   baseBranch: string;
   /** Path to the git worktree on disk */
   worktreePath: string;
+  /**
+   * True when Claude had finished its work and the session was idle at the
+   * time the task was persisted. Used to distinguish "deer was closed while
+   * Claude was done" from "deer was closed while Claude was still running".
+   */
+  idle?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Task

> we continue to have problems with 'shared state' or 'restoring state' across different deer CLI instances, or even if we close down deer and re-open it trying to get our tasks back. Examine all the code for that in detail and find issues.

## Summary

Several interrelated bugs caused tasks to be incorrectly shown as interrupted, lose their idle/PR-ready state, or race between instances when deer was closed and reopened or when multiple CLI instances were running simultaneously.

Root causes addressed:
- `historicalAgent` did not preserve the `idle` flag, so tasks where Claude had finished but no PR was created lost the "create PR" action on restore.
- `historicalAgentFromStateFile` always set status to `"interrupted"`, overriding terminal statuses like `cancelled`, `failed`, and `pr_failed`.
- `removeTaskState` was called unconditionally in the agent teardown path, racing with `retryAgent` which reuses the same `taskId` and manages `state.json` itself.
- `useAgentSync` did not short-circuit when the current process already owns the task, causing live agents to be replaced by state-file reconstructions.
- The live-session resume path conditionally skipped adding the taskId to `liveSessionIdsRef`, allowing a second sync tick to show the task as interrupted before the poll loop claimed it.

## Changes

- **`src/agent-state.ts`**: Preserve `idle` flag in `historicalAgent`; only override `lastActivity` for non-idle interrupted tasks. Introduce `TERMINAL_STATUSES` set and use it in `historicalAgentFromStateFile` to preserve `cancelled`/`failed`/`pr_failed` instead of overriding with `"interrupted"`.
- **`src/hooks/useAgentActions.ts`**: Move `removeTaskState` inside the `!agent.deleted` guard so it is skipped when `retryAgent` reuses the taskId. Set `agent.deleted = true` before killing the tmux session in the retry path. Persist `idle` field when saving to history.
- **`src/hooks/useAgentSync.ts`**: Add early-exit branch when the current process owns the task (`ownerPid === process.pid`), preserving the existing live agent. Always add taskId to `liveSessionIdsRef` when a tmux session is alive (not only on first discovery) to prevent a second tick from showing the task as interrupted.
- **`src/task.ts`**: Add optional `idle` field to `PersistedTask` interface to distinguish "Claude finished, deer closed" from "Claude was still running when deer closed".

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.