### PR TITLE
🦌 Allow PR creation from interrupted state

### DIFF
--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -80,7 +80,7 @@ const ACTIONS_BY_STATE: Record<AgentStatus, AgentAction[]> = {
   teardown:    ["open_shell", "delete", "toggle_logs"],
   failed:      ["retry", "open_shell", "delete", "toggle_logs"],
   cancelled:   ["retry", "open_shell", "delete", "toggle_logs"],
-  interrupted: ["retry", "open_shell", "delete", "toggle_logs"],
+  interrupted: ["create_pr", "retry", "open_shell", "delete", "toggle_logs"],
   pr_failed:   ["attach", "create_pr", "open_shell", "delete", "toggle_logs", "retry"],
 };
 

--- a/test/state-machine.test.ts
+++ b/test/state-machine.test.ts
@@ -159,6 +159,25 @@ describe("availableActions", () => {
     expect(actions).toContain("toggle_logs");
     expect(actions).not.toContain("attach");
   });
+
+  test("interrupted state with branch allows create_pr", () => {
+    const actions = availableActions(baseCtx({
+      status: "interrupted",
+      hasFinalBranch: true,
+      hasPrUrl: false,
+    }));
+    expect(actions).toContain("create_pr");
+  });
+
+  test("interrupted state with existing open PR does not allow create_pr", () => {
+    const actions = availableActions(baseCtx({
+      status: "interrupted",
+      hasFinalBranch: true,
+      hasPrUrl: true,
+      prState: "open",
+    }));
+    expect(actions).not.toContain("create_pr");
+  });
   test("idle running state has create_pr and retry available", () => {
     const actions = availableActions(baseCtx({
       status: "running",


### PR DESCRIPTION
## Task

> PR creation doesnt work on idle tasks sometimes, e.g. the current 'bun install is not allowed...' task, we cant create a PR

## Summary

Tasks that end up in the `interrupted` state (e.g. when the sandbox blocks a command) were missing the `create_pr` action from their available actions list. This meant users could not create a PR from an interrupted task even if a branch had been pushed.

## Changes

- `src/state-machine.ts`: Added `create_pr` to the allowed actions for the `interrupted` state
- `test/state-machine.test.ts`: Added tests verifying `create_pr` is available in `interrupted` state with a branch, and not available when a PR already exists

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.