### PR TITLE
Add bun ecosystem plugin for sandbox support

### DIFF
--- a/src/ecosystems.ts
+++ b/src/ecosystems.ts
@@ -83,11 +83,31 @@ const goPlugin: EcosystemPlugin = {
   ],
 };
 
+const bunPlugin: EcosystemPlugin = {
+  name: "bun",
+  detect: async (repoPath) => {
+    const [hasLockb, hasLock] = await Promise.all([
+      pathExists(join(repoPath, "bun.lockb")),
+      pathExists(join(repoPath, "bun.lock")),
+    ]);
+    return hasLockb || hasLock;
+  },
+  strategies: [
+    // Redirect bun's package cache to a writable dir inside the worktree.
+    // The default ~/.bun/install/cache is read-only in the sandbox.
+    { type: "env", vars: { BUN_INSTALL_CACHE_DIR: ".bun-install-cache" } },
+    // Prepopulate node_modules from the host repo to avoid network installs.
+    { type: "prepopulate", source: "node_modules", lockfile: "bun.lockb" },
+    { type: "prepopulate", source: "node_modules", lockfile: "bun.lock" },
+  ],
+};
+
 export const BUILTIN_PLUGINS: EcosystemPlugin[] = [
   uvPlugin,
   pnpmPlugin,
   npmPlugin,
   goPlugin,
+  bunPlugin,
 ];
 
 // ── Core ──────────────────────────────────────────────────────────────────────

--- a/test/ecosystems.test.ts
+++ b/test/ecosystems.test.ts
@@ -53,6 +53,20 @@ describe("ecosystems", () => {
       await writeFile(join(repoPath, "go.mod"), "");
       expect(await goPlugin.detect(repoPath)).toBe(true);
     });
+
+    test("bunPlugin detects bun.lockb", async () => {
+      const bunPlugin = BUILTIN_PLUGINS.find((p) => p.name === "bun")!;
+      expect(await bunPlugin.detect(repoPath)).toBe(false);
+      await writeFile(join(repoPath, "bun.lockb"), "");
+      expect(await bunPlugin.detect(repoPath)).toBe(true);
+    });
+
+    test("bunPlugin detects bun.lock", async () => {
+      const bunPlugin = BUILTIN_PLUGINS.find((p) => p.name === "bun")!;
+      expect(await bunPlugin.detect(repoPath)).toBe(false);
+      await writeFile(join(repoPath, "bun.lock"), "");
+      expect(await bunPlugin.detect(repoPath)).toBe(true);
+    });
   });
 
   describe("env strategy", () => {
@@ -187,6 +201,38 @@ describe("ecosystems", () => {
 
       expect(await Bun.file(join(worktreePath, ".venv", "existing.txt")).exists()).toBe(true);
       expect(await Bun.file(join(worktreePath, ".venv", "pyvenv.cfg")).exists()).toBe(false);
+    });
+  });
+
+  describe("bun ecosystem", () => {
+    test("sets BUN_INSTALL_CACHE_DIR inside worktree", async () => {
+      await writeFile(join(repoPath, "bun.lockb"), "");
+      const result = await applyEcosystems(repoPath, worktreePath);
+      expect(result.env.BUN_INSTALL_CACHE_DIR).toBe(join(worktreePath, ".bun-install-cache"));
+    });
+
+    test("prepopulates node_modules when bun.lockb matches", async () => {
+      const lockContent = "bun lock content";
+      await writeFile(join(repoPath, "bun.lockb"), lockContent);
+      await writeFile(join(worktreePath, "bun.lockb"), lockContent);
+      await mkdir(join(repoPath, "node_modules", "pkg"), { recursive: true });
+      await writeFile(join(repoPath, "node_modules", "pkg", "index.js"), "module.exports = {}");
+
+      await applyEcosystems(repoPath, worktreePath);
+
+      expect(await Bun.file(join(worktreePath, "node_modules", "pkg", "index.js")).exists()).toBe(true);
+    });
+
+    test("prepopulates node_modules when bun.lock matches", async () => {
+      const lockContent = "bun text lock content";
+      await writeFile(join(repoPath, "bun.lock"), lockContent);
+      await writeFile(join(worktreePath, "bun.lock"), lockContent);
+      await mkdir(join(repoPath, "node_modules", "pkg"), { recursive: true });
+      await writeFile(join(repoPath, "node_modules", "pkg", "index.js"), "module.exports = {}");
+
+      await applyEcosystems(repoPath, worktreePath);
+
+      expect(await Bun.file(join(worktreePath, "node_modules", "pkg", "index.js")).exists()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a `bun` ecosystem plugin that detects `bun.lockb` / `bun.lock` repos
- Sets `BUN_INSTALL_CACHE_DIR` to a writable path inside the worktree (the default `~/.bun/install/cache` is read-only in the sandbox, causing `bun install` to fail)
- Prepopulates `node_modules` from the host repo when the lockfile matches, avoiding network installs

## Test plan
- [x] Detection tests: `bunPlugin` returns false when no lockfile, true for `bun.lockb`, true for `bun.lock`
- [x] `BUN_INSTALL_CACHE_DIR` resolves to `<worktreePath>/.bun-install-cache`
- [x] Prepopulate works for both `bun.lockb` and `bun.lock` lockfile formats
- [x] All 21 ecosystem tests pass, no regressions in other test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)