### PR TITLE
🦌 when we attach/detach, the state of the task (before idle chec...

### DIFF
--- a/src/hooks/useAgentActions.ts
+++ b/src/hooks/useAgentActions.ts
@@ -328,12 +328,22 @@ export function useAgentActions({
     }
 
     if (agent.status === "running") {
+      const prevIdle = agent.idle;
+      const prevLastActivity = agent.lastActivity;
       const lines = await captureTmuxPane(sessionName);
       if (lines) {
-        paneStateRef.current.set(agent.taskId, seedIdleState(captureSnapshot(lines)));
+        const snap = captureSnapshot(lines);
+        // If already idle before attach, seed at threshold so the poll loop
+        // doesn't need to re-accumulate idle counts. Otherwise reset to zero
+        // so a non-idle agent doesn't flip to idle just because we attached.
+        paneStateRef.current.set(
+          agent.taskId,
+          prevIdle ? seedIdleState(snap) : { snapshot: snap, unchangedCount: 0 },
+        );
       }
-      agent.idle = true;
-      agent.lastActivity = t("activity_idle_attach");
+      // Restore pre-attach state so the spinner/wave emoji stays consistent
+      agent.idle = prevIdle;
+      agent.lastActivity = prevLastActivity;
       setAgents((prev) => [...prev]);
     }
   }, [setSuspended]);


### PR DESCRIPTION
## Summary

> when we attach/detach, the state of the task (before idle checking triggers again) should default to whatever it was when we attached, when we detach. this is so that the spinner/wave emoji appear con...

### Commits

```
a62b8dd deer: pending PR metadata
```

---
> Created by [deer](https://github.com/zdavison/deer) — review carefully.