### PR TITLE
🦌 Allow sandbox writes to worktree git metadata directory

### DIFF
--- a/packages/deerbox/src/sandbox/srt.ts
+++ b/packages/deerbox/src/sandbox/srt.ts
@@ -1,5 +1,5 @@
 import { join, dirname } from "node:path";
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import type { SandboxRuntime, SandboxRuntimeOptions, SandboxCleanup } from "./runtime";
 import { HOME } from "../constants";
@@ -85,6 +85,27 @@ function buildHomeDenyList(requiredPaths: string[]): string[] {
 }
 
 /**
+ * Resolve the git worktree's gitdir from its .git file.
+ *
+ * In git worktrees, the worktree directory contains a .git FILE (not a
+ * directory) with a `gitdir: <path>` line pointing to the real metadata
+ * directory inside the main repo's .git/worktrees/<name>/. The sandbox must
+ * allow writes to this path so git operations (add, commit, etc.) succeed.
+ *
+ * Returns null if the .git file is absent or not a worktree .git file.
+ */
+function resolveWorktreeGitDir(worktreePath: string): string | null {
+  try {
+    const content = readFileSync(join(worktreePath, ".git"), "utf-8").trim();
+    const match = content.match(/^gitdir:\s*(.+)$/m);
+    if (match) return match[1].trim();
+  } catch {
+    // No .git file or unreadable — not a worktree
+  }
+  return null;
+}
+
+/**
  * Build an SRT settings JSON object from deer's sandbox options.
  */
 function buildSrtSettings(options: SandboxRuntimeOptions, srtBinDir: string | null): Record<string, unknown> {
@@ -103,6 +124,9 @@ function buildSrtSettings(options: SandboxRuntimeOptions, srtBinDir: string | nu
     // The Unix socket must be accessible from inside the sandbox
     network.allowUnixSockets = [dirname(options.mitmProxy.socketPath)];
   }
+
+  // The worktree's git metadata lives in the main repo's .git/worktrees/<name>/
+  const worktreeGitDir = resolveWorktreeGitDir(options.worktreePath);
 
   // Collect paths that must stay readable: worktree, repo .git dir,
   // PATH entries under HOME, and the deer data dir (worktree parent).
@@ -124,6 +148,9 @@ function buildSrtSettings(options: SandboxRuntimeOptions, srtBinDir: string | nu
       denyRead,
       allowWrite: [
         options.worktreePath,
+        // The worktree's actual git metadata lives in the main repo's
+        // .git/worktrees/<name>/ — allow writes so git add/commit work.
+        ...(worktreeGitDir ? [worktreeGitDir] : []),
         claudeDir,
         join(HOME, ".claude.json"),
         "/tmp",

--- a/test/sandbox/srt-settings.test.ts
+++ b/test/sandbox/srt-settings.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests that srt-settings.json allows writes to the worktree's gitdir,
+ * which lives inside the main repo's .git/worktrees/<name>/ directory.
+ *
+ * Git worktrees store their metadata (index, HEAD, etc.) in the main repo's
+ * .git/worktrees/<name>/ — not inside the worktree itself. The sandbox must
+ * allow writes there so git operations (add, commit) succeed.
+ */
+import { test, expect, describe, afterEach } from "bun:test";
+import { createSrtRuntime } from "../../packages/deerbox/src/index";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("srt settings - worktree gitdir write permission", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of tmpDirs.splice(0)) {
+      await rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "deer-srt-test-"));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  test("worktree gitdir is included in allowWrite when .git file is present", async () => {
+    // Simulate the main repo's .git directory
+    const repoGitDir = await makeTmpDir();
+    // Git creates .git/worktrees/<name>/ to store worktree-specific metadata
+    const worktreeGitDir = join(repoGitDir, "worktrees", "task1");
+    await mkdir(worktreeGitDir, { recursive: true });
+
+    // The worktree directory has a .git FILE (not dir) pointing to the gitdir
+    const worktreeDir = await makeTmpDir();
+    await writeFile(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+
+    const runtime = createSrtRuntime();
+    await runtime.prepare?.({
+      worktreePath: worktreeDir,
+      repoGitDir,
+      allowlist: [],
+    });
+
+    const settingsPath = join(worktreeDir, "..", "srt-settings.json");
+    const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+    const allowWrite: string[] = settings.filesystem.allowWrite;
+
+    expect(allowWrite).toContain(worktreeGitDir);
+  });
+
+  test("allowWrite does not include non-existent gitdir when .git file is absent", async () => {
+    // A plain worktree dir with no .git file (e.g., the main worktree itself)
+    const worktreeDir = await makeTmpDir();
+
+    const runtime = createSrtRuntime();
+    await runtime.prepare?.({
+      worktreePath: worktreeDir,
+      allowlist: [],
+    });
+
+    const settingsPath = join(worktreeDir, "..", "srt-settings.json");
+    const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+    const allowWrite: string[] = settings.filesystem.allowWrite;
+
+    // No extra paths added beyond the defaults
+    expect(allowWrite).toContain(worktreeDir);
+    // No path from a missing .git file should sneak in
+    const extraPaths = allowWrite.filter(
+      (p) =>
+        p !== worktreeDir &&
+        !p.includes(".claude") &&
+        p !== "/tmp" &&
+        p !== "/private/tmp"
+    );
+    expect(extraPaths).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Task

> Git worktrees store their metadata (index, HEAD, etc.) in the main repo's `.git/worktrees/<name>/` — not inside the worktree itself. The sandbox must allow writes there so git operations (add, commit) succeed.

## Summary

Git worktrees use a `.git` FILE (not directory) in the worktree root that points to the real metadata directory inside the main repo's `.git/worktrees/<name>/`. Without write access to that path, git operations like `git add` and `git commit` fail with "Read-only file system" errors inside the sandbox.

This adds a `resolveWorktreeGitDir` helper that reads the `.git` file and extracts the `gitdir:` path, then includes that path in the SRT `allowWrite` list so git operations work correctly inside deerbox sandboxes.

## Changes

- `packages/deerbox/src/sandbox/srt.ts`: Added `resolveWorktreeGitDir()` to parse the worktree `.git` file and extract the `gitdir` path; included resolved gitdir in `allowWrite` when present
- `test/sandbox/srt-settings.test.ts`: Added tests verifying the worktree gitdir is included in `allowWrite` when a `.git` file is present, and excluded when absent

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.