### PR TITLE
🦌 Log ecosystem preparation and plugin activity during worktree setup

### DIFF
--- a/packages/deerbox/src/ecosystems.ts
+++ b/packages/deerbox/src/ecosystems.ts
@@ -119,12 +119,14 @@ export const BUILTIN_PLUGINS: EcosystemPlugin[] = [
  * @param worktreePath - Path to the agent's git worktree
  * @param disabledEcosystems - Plugin names to skip
  * @param plugins - Override the plugin list (defaults to BUILTIN_PLUGINS)
+ * @param onStatus - Optional callback for status/progress messages
  */
 export async function applyEcosystems(
   repoPath: string,
   worktreePath: string,
   disabledEcosystems?: string[],
   plugins?: EcosystemPlugin[],
+  onStatus?: (message: string) => void,
 ): Promise<EcosystemResult> {
   const HOME = process.env.HOME ?? "";
   const effectivePlugins = (plugins ?? BUILTIN_PLUGINS).filter(
@@ -133,6 +135,10 @@ export async function applyEcosystems(
 
   const detected = await Promise.all(effectivePlugins.map((p) => p.detect(repoPath)));
   const activePlugins = effectivePlugins.filter((_, i) => detected[i]);
+
+  if (activePlugins.length > 0) {
+    onStatus?.(`Preparing ecosystems: ${activePlugins.map((p) => p.name).join(", ")}`);
+  }
 
   const extraReadPathsSet = new Set<string>();
   const env: Record<string, string> = {};
@@ -177,6 +183,8 @@ export async function applyEcosystems(
           ]);
 
           if (repoContent !== worktreeContent) continue;
+
+          onStatus?.(`[${plugin.name}] Prepopulating ${strategy.source}...`);
 
           const cpCmd = process.platform === "darwin"
             ? Bun.$`cp -cR ${repoSource} ${worktreeDest}`.quiet()

--- a/packages/deerbox/src/session.ts
+++ b/packages/deerbox/src/session.ts
@@ -132,6 +132,8 @@ export async function prepare(options: PrepareOptions): Promise<PreparedSession>
       repoPath,
       worktreePath,
       config.sandbox.ecosystems?.disabled,
+      undefined,
+      onStatus,
     );
   } else {
     onStatus?.("Creating worktree...");
@@ -148,6 +150,8 @@ export async function prepare(options: PrepareOptions): Promise<PreparedSession>
       repoPath,
       worktreePath,
       config.sandbox.ecosystems?.disabled,
+      undefined,
+      onStatus,
     );
   }
 


### PR DESCRIPTION
## Task

> when deerbox runs, we want to log when ecosystem preparation is happening when setting up the worktree, and which plugins are running

## Summary

Adds status/progress logging to the ecosystem preparation step of worktree setup. Previously, `applyEcosystems` had no way to surface what was happening internally. Now it accepts an optional `onStatus` callback and emits messages when active plugins are detected and when individual plugin prepopulation steps run.

## Changes

- `packages/deerbox/src/ecosystems.ts`: Added optional `onStatus` callback parameter to `applyEcosystems`; emits a summary of active plugin names before preparation begins, and per-plugin messages during file prepopulation
- `packages/deerbox/src/session.ts`: Passes the existing `onStatus` callback through to both `applyEcosystems` call sites

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.