### PR TITLE
🦌 Exclude npm plugin when bun lockfiles are present

### DIFF
--- a/packages/deerbox/src/ecosystems.ts
+++ b/packages/deerbox/src/ecosystems.ts
@@ -63,11 +63,13 @@ const pnpmPlugin: EcosystemPlugin = {
 const npmPlugin: EcosystemPlugin = {
   name: "npm",
   detect: async (repoPath) => {
-    const [hasPackageLock, hasPnpmLock] = await Promise.all([
+    const [hasPackageLock, hasPnpmLock, hasBunLock, hasBunLockb] = await Promise.all([
       pathExists(join(repoPath, "package-lock.json")),
       pathExists(join(repoPath, "pnpm-lock.yaml")),
+      pathExists(join(repoPath, "bun.lock")),
+      pathExists(join(repoPath, "bun.lockb")),
     ]);
-    return hasPackageLock && !hasPnpmLock;
+    return hasPackageLock && !hasPnpmLock && !hasBunLock && !hasBunLockb;
   },
   strategies: [
     { type: "prepopulate", source: "node_modules", lockfile: "package-lock.json" },

--- a/test/ecosystems.test.ts
+++ b/test/ecosystems.test.ts
@@ -47,6 +47,22 @@ describe("ecosystems", () => {
       expect(await npmPlugin.detect(repoPath)).toBe(false);
     });
 
+    test("npmPlugin excluded when bun.lockb is present", async () => {
+      const npmPlugin = BUILTIN_PLUGINS.find((p) => p.name === "npm")!;
+      await writeFile(join(repoPath, "package-lock.json"), "");
+      expect(await npmPlugin.detect(repoPath)).toBe(true);
+      await writeFile(join(repoPath, "bun.lockb"), "");
+      expect(await npmPlugin.detect(repoPath)).toBe(false);
+    });
+
+    test("npmPlugin excluded when bun.lock is present", async () => {
+      const npmPlugin = BUILTIN_PLUGINS.find((p) => p.name === "npm")!;
+      await writeFile(join(repoPath, "package-lock.json"), "");
+      expect(await npmPlugin.detect(repoPath)).toBe(true);
+      await writeFile(join(repoPath, "bun.lock"), "");
+      expect(await npmPlugin.detect(repoPath)).toBe(false);
+    });
+
     test("goPlugin returns false when go.mod absent, true when present", async () => {
       const goPlugin = BUILTIN_PLUGINS.find((p) => p.name === "go")!;
       expect(await goPlugin.detect(repoPath)).toBe(false);


### PR DESCRIPTION
## Summary

The npm ecosystem plugin was incorrectly detected in Bun projects that also had a `package-lock.json`. This change adds detection for both `bun.lock` and `bun.lockb` lockfiles, so that the npm plugin is excluded when a Bun project is detected.

## Changes

- `packages/deerbox/src/ecosystems.ts`: Updated `npmPlugin.detect` to check for `bun.lock` and `bun.lockb` in addition to `pnpm-lock.yaml`, excluding npm when either Bun lockfile is present
- `test/ecosystems.test.ts`: Added two tests verifying that `npmPlugin` returns `false` when `bun.lockb` or `bun.lock` is present alongside `package-lock.json`

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.