### PR TITLE
🦌 Fix updater re-exec dropping first argument

### DIFF
--- a/packages/shared/src/updater.ts
+++ b/packages/shared/src/updater.ts
@@ -111,7 +111,7 @@ export async function checkAndUpdate({ name, version }: UpdateOptions): Promise<
   // Re-exec the new binary, replacing this process.
   // Set DEER_UPDATED to prevent infinite update loops if the new binary
   // still reports an old version.
-  const proc = Bun.spawn([currentPath, ...process.argv.slice(1)], {
+  const proc = Bun.spawn([currentPath, ...process.argv.slice(2)], {
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",


### PR DESCRIPTION
## Summary

Fixes a bug in the self-updater where the process was re-executed with incorrect arguments after a binary update. `process.argv.slice(1)` was including the old binary path as an argument, causing the re-spawned process to receive a shifted argument list. Changing to `slice(2)` correctly skips both the runtime and script path entries.

## Changes

- `packages/shared/src/updater.ts`: Fix `process.argv.slice(1)` → `slice(2)` in post-update re-exec to pass correct arguments to the new binary

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.