### PR TITLE
🦌 Fix deerbox binary resolution in compiled mode

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -124,7 +124,7 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
       // Re-run reconcile immediately so proxies are restored for any
       // running cross-instance tasks without waiting for the 2s poll.
       reconcile();
-    });
+    }).catch(() => { /* config failure is non-fatal; defaults will be used */ });
   }, [cwd]);
 
   // ── Cleanup on unmount ────────────────────────────────────────────
@@ -213,8 +213,8 @@ export default function Dashboard({ cwd, mockAgents }: { cwd: string; mockAgents
       {/* Preflight errors */}
       {preflight && !preflight.ok && (
         <Box flexDirection="column" paddingX={1}>
-          {preflight.errors.map((e) => (
-            <Text key={e} color="red">✗ {e}</Text>
+          {preflight.errors.map((e, i) => (
+            <Text key={i} color="red">✗ {e.split("\n")[0]}</Text>
           ))}
         </Box>
       )}

--- a/src/deerbox.ts
+++ b/src/deerbox.ts
@@ -8,39 +8,69 @@
 import { join, dirname } from "node:path";
 import type { DeerConfig, PreflightResult, PrepareResult } from "./types";
 
+export interface DeerboxBinOptions {
+  /**
+   * Override dev mode detection. In dev mode, TypeScript script fallbacks are tried.
+   * In compiled binary mode, `process.execPath` is the compiled deer binary — NOT bun —
+   * so running `.ts` scripts with it would launch the TUI instead of the CLI.
+   * @default detected from process.argv[1] (true when argv[1] ends with .ts/.tsx)
+   */
+  isDevMode?: boolean;
+  /**
+   * Override process.argv[0] for testing.
+   * @default process.argv[0]
+   */
+  argv0?: string;
+}
+
 /**
  * Resolve the deerbox binary/script path.
  *
  * Search order:
  * 1. Sibling binary (compiled: deer and deerbox in same directory)
- * 2. Workspace source (dev: packages/deerbox/src/cli.ts via bun)
- * 3. PATH lookup
+ * 2. Workspace source (dev mode only: packages/deerbox/src/cli.ts via bun)
+ * 3. cwd-relative source (dev mode only: for tests run from repo root)
+ * 4. PATH lookup
+ *
+ * TypeScript script fallbacks (2, 3) are skipped in compiled binary mode because
+ * `process.execPath` is the compiled deer binary there, not bun. Spawning the deer
+ * binary with a `.ts` argument would silently launch the TUI instead of the CLI.
  */
-function deerboxBin(): string[] {
+export function deerboxBin(opts: DeerboxBinOptions = {}): string[] {
   const { accessSync, constants } = require("node:fs") as typeof import("node:fs");
 
+  const argv0 = opts.argv0 ?? process.argv[0];
+  const devMode = opts.isDevMode ?? (
+    (process.argv[1] ?? "").endsWith(".ts") ||
+    (process.argv[1] ?? "").endsWith(".tsx")
+  );
+
   // 1. Sibling binary (production: deer and deerbox compiled to same dir)
-  const selfDir = dirname(process.argv[0]);
+  const selfDir = dirname(argv0);
   const sibling = join(selfDir, "deerbox");
   try {
     accessSync(sibling, constants.X_OK);
     return [sibling];
   } catch { /* not found */ }
 
-  // 2. Workspace source relative to this module (dev)
-  const moduleDir = typeof import.meta.dir === "string" ? import.meta.dir : selfDir;
-  const workspaceScript = join(moduleDir, "..", "packages", "deerbox", "src", "cli.ts");
-  try {
-    accessSync(workspaceScript);
-    return [process.execPath, workspaceScript];
-  } catch { /* not found */ }
+  // 2–3. TypeScript script fallbacks — dev mode only.
+  // In compiled binary mode, process.execPath is the compiled deer binary, not bun.
+  if (devMode) {
+    // 2. Workspace source relative to this module (dev)
+    const moduleDir = typeof import.meta.dir === "string" ? import.meta.dir : selfDir;
+    const workspaceScript = join(moduleDir, "..", "packages", "deerbox", "src", "cli.ts");
+    try {
+      accessSync(workspaceScript);
+      return [process.execPath, workspaceScript];
+    } catch { /* not found */ }
 
-  // 3. Try relative to cwd (tests)
-  const cwdScript = join(process.cwd(), "packages", "deerbox", "src", "cli.ts");
-  try {
-    accessSync(cwdScript);
-    return [process.execPath, cwdScript];
-  } catch { /* not found */ }
+    // 3. Try relative to cwd (tests)
+    const cwdScript = join(process.cwd(), "packages", "deerbox", "src", "cli.ts");
+    try {
+      accessSync(cwdScript);
+      return [process.execPath, cwdScript];
+    } catch { /* not found */ }
+  }
 
   // 4. Fall back to PATH
   return ["deerbox"];

--- a/test/deerbox-bin.test.ts
+++ b/test/deerbox-bin.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, describe } from "bun:test";
+import { deerboxBin } from "../src/deerbox";
+
+describe("deerboxBin", () => {
+  describe("compiled binary mode (isDevMode=false)", () => {
+    test("does not return a TypeScript script path", () => {
+      // In compiled mode we're running from a dir that contains packages/deerbox/src/cli.ts
+      // (the deer repo itself). The old bug: process.execPath + that script = launches deer TUI.
+      const result = deerboxBin({ isDevMode: false, argv0: "/some/compiled/deer" });
+      expect(result.some((s) => s.endsWith(".ts"))).toBe(false);
+    });
+
+    test("returns PATH fallback ['deerbox'] when no sibling binary exists", () => {
+      const result = deerboxBin({
+        isDevMode: false,
+        argv0: "/nonexistent/dir/deer",
+      });
+      // Should be PATH fallback, not a TypeScript script invocation
+      expect(result).toEqual(["deerbox"]);
+    });
+  });
+
+  describe("dev mode (isDevMode=true)", () => {
+    test("returns TypeScript workspace script when running from deer repo", () => {
+      // In dev mode, the workspace cli.ts should be found relative to this file's directory
+      const result = deerboxBin({ isDevMode: true, argv0: process.argv[0] });
+      // Should resolve to [bun, .../packages/deerbox/src/cli.ts]
+      expect(result.length).toBe(2);
+      expect(result[1]).toMatch(/packages\/deerbox\/src\/cli\.ts$/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where `deerboxBin` would attempt to spawn TypeScript scripts (`.ts` fallbacks) even when running as a compiled binary. In compiled mode, `process.execPath` points to the deer binary itself — not bun — so passing a `.ts` script path would silently launch the TUI instead of the deerbox CLI.

The fix gates the TypeScript script fallbacks behind a dev mode check, and exports `deerboxBin` with an options interface so it can be tested in isolation.

Also tightens up minor UI issues in the dashboard: config load failures are now silently swallowed (non-fatal), and preflight error display is truncated to the first line to avoid multi-line noise.

## Changes

- **`src/deerbox.ts`**: Export `deerboxBin` and add `DeerboxBinOptions` interface with `isDevMode` and `argv0` overrides; skip `.ts` script fallbacks (search steps 2–3) when not in dev mode
- **`src/dashboard.tsx`**: Catch and ignore config load errors; truncate preflight error messages to first line only; use index-based React keys for error list
- **`test/deerbox-bin.test.ts`**: New test file covering compiled mode (no `.ts` paths, PATH fallback) and dev mode (resolves workspace cli.ts)

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.