### PR TITLE
🦌 Inject PR review comments as prompt context

### DIFF
--- a/packages/deerbox/src/cli.ts
+++ b/packages/deerbox/src/cli.ts
@@ -27,6 +27,7 @@ import { dataDir } from "./task";
 import { createPullRequest, updatePullRequest, hasChanges } from "./git/finalize";
 import { runPostSession, interactivePromptChoice, defaultOpenShell, defaultMergeBranch } from "./post-session";
 import { prune } from "./prune";
+import { fetchPRComments } from "./pr-comments";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -249,9 +250,18 @@ async function cmdRun(prompt: string | undefined, args: string[]) {
     }
   }
 
+  // If --from resolved to a PR, fetch review comments and prepend as context
+  let effectivePrompt = prompt;
+  if (fromResolution?.prUrl) {
+    const comments = await fetchPRComments(fromResolution.prUrl);
+    if (comments) {
+      effectivePrompt = prompt ? `${comments}\n\n${prompt}` : comments;
+    }
+  }
+
   const session = await prepare({
     repoPath,
-    prompt,
+    prompt: effectivePrompt,
     baseBranch: fromResolution?.baseBranch ?? effectiveBranch,
     fromBranch: fromResolution?.branch,
     config,
@@ -293,7 +303,7 @@ async function cmdRun(prompt: string | undefined, args: string[]) {
       worktreePath: session.worktreePath,
       branch: session.branch,
       baseBranch: postSessionBaseBranch,
-      prompt: prompt ?? null,
+      prompt: effectivePrompt ?? null,
       fromPrUrl: fromPrUrl ?? undefined,
       originalBranch,
     },

--- a/packages/deerbox/src/index.ts
+++ b/packages/deerbox/src/index.ts
@@ -51,6 +51,10 @@ export type { PostSessionChoice, PostSessionOutcome, PostSessionDeps, PostSessio
 export { prune, isTmuxSessionAlive, getRepoPathFromWorktree } from "./prune";
 export type { PruneResult, PruneOptions } from "./prune";
 
+// PR comments context
+export { fetchPRComments, formatPRComments } from "./pr-comments";
+export type { PRReviewComment, PRIssueComment, GhApiRunner } from "./pr-comments";
+
 // Utilities
 export { generateTaskId, dataDir } from "./task";
 export { detectLang, setLang, getLang, getPRLanguage } from "@deer/shared";

--- a/packages/deerbox/src/pr-comments.ts
+++ b/packages/deerbox/src/pr-comments.ts
@@ -1,0 +1,110 @@
+/**
+ * Fetch and format PR review comments for injection into Claude's prompt context.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface PRReviewComment {
+  user: { login: string };
+  body: string;
+  /** File path for inline diff comments */
+  path?: string;
+  /** Line number for inline diff comments */
+  line?: number;
+}
+
+export interface PRIssueComment {
+  user: { login: string };
+  body: string;
+}
+
+/**
+ * Runs a `gh api <endpoint>` call and returns stdout + exit code.
+ * Injectable for testing.
+ */
+export type GhApiRunner = (endpoint: string) => Promise<{ stdout: string; exitCode: number }>;
+
+// ── Pure formatting ───────────────────────────────────────────────────
+
+/**
+ * Format fetched PR comments into a context block for Claude.
+ * Returns null if there are no non-empty comments.
+ */
+export function formatPRComments(
+  reviewComments: PRReviewComment[],
+  issueComments: PRIssueComment[],
+): string | null {
+  const lines: string[] = [];
+
+  for (const c of reviewComments) {
+    const body = c.body.trim();
+    if (!body) continue;
+    const location = c.path
+      ? c.line != null
+        ? `on ${c.path} line ${c.line}`
+        : `on ${c.path}`
+      : null;
+    const header = location
+      ? `[Review by @${c.user.login} ${location}]`
+      : `[Review by @${c.user.login}]`;
+    lines.push(header, body, "");
+  }
+
+  for (const c of issueComments) {
+    const body = c.body.trim();
+    if (!body) continue;
+    lines.push(`[Comment by @${c.user.login}]`, body, "");
+  }
+
+  if (lines.length === 0) return null;
+
+  // Remove trailing blank line
+  while (lines.at(-1) === "") lines.pop();
+
+  return `PR Review Comments:\n\n${lines.join("\n")}`;
+}
+
+// ── Fetching ──────────────────────────────────────────────────────────
+
+function parsePRUrl(prUrl: string): { owner: string; repo: string; number: string } | null {
+  const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: match[3] };
+}
+
+const defaultRunner: GhApiRunner = async (endpoint) => {
+  const result = await Bun.$`gh api ${endpoint}`.quiet().nothrow();
+  return { stdout: result.stdout.toString(), exitCode: result.exitCode };
+};
+
+/**
+ * Fetch PR review and issue comments from GitHub and return a formatted
+ * context block, or null if there are no comments or on failure.
+ */
+export async function fetchPRComments(prUrl: string, runner: GhApiRunner = defaultRunner): Promise<string | null> {
+  const parsed = parsePRUrl(prUrl);
+  if (!parsed) return null;
+
+  const { owner, repo, number } = parsed;
+
+  let reviewComments: PRReviewComment[] = [];
+  let issueComments: PRIssueComment[] = [];
+
+  try {
+    const [reviewRes, issueRes] = await Promise.all([
+      runner(`/repos/${owner}/${repo}/pulls/${number}/comments`),
+      runner(`/repos/${owner}/${repo}/issues/${number}/comments`),
+    ]);
+
+    if (reviewRes.exitCode === 0) {
+      reviewComments = JSON.parse(reviewRes.stdout) as PRReviewComment[];
+    }
+    if (issueRes.exitCode === 0) {
+      issueComments = JSON.parse(issueRes.stdout) as PRIssueComment[];
+    }
+  } catch {
+    return null;
+  }
+
+  return formatPRComments(reviewComments, issueComments);
+}

--- a/test/pr-comments.test.ts
+++ b/test/pr-comments.test.ts
@@ -1,0 +1,144 @@
+import { test, expect, describe } from "bun:test";
+import { formatPRComments, fetchPRComments } from "deerbox";
+import type { PRReviewComment, PRIssueComment, GhApiRunner } from "deerbox";
+
+// ── formatPRComments ──────────────────────────────────────────────────
+
+describe("formatPRComments", () => {
+  test("returns null when both arrays are empty", () => {
+    expect(formatPRComments([], [])).toBeNull();
+  });
+
+  test("formats inline review comments with file and line", () => {
+    const reviewComments: PRReviewComment[] = [
+      { user: { login: "alice" }, body: "Add a null check here.", path: "src/auth.ts", line: 42 },
+    ];
+    const result = formatPRComments(reviewComments, []);
+    expect(result).toContain("PR Review Comments:");
+    expect(result).toContain("[Review by @alice on src/auth.ts line 42]");
+    expect(result).toContain("Add a null check here.");
+  });
+
+  test("formats inline review comments without line number", () => {
+    const reviewComments: PRReviewComment[] = [
+      { user: { login: "bob" }, body: "Consider a helper.", path: "src/utils.ts" },
+    ];
+    const result = formatPRComments(reviewComments, []);
+    expect(result).toContain("[Review by @bob on src/utils.ts]");
+    expect(result).toContain("Consider a helper.");
+  });
+
+  test("formats issue-level comments", () => {
+    const issueComments: PRIssueComment[] = [
+      { user: { login: "carol" }, body: "Overall LGTM but please add tests." },
+    ];
+    const result = formatPRComments([], issueComments);
+    expect(result).toContain("PR Review Comments:");
+    expect(result).toContain("[Comment by @carol]");
+    expect(result).toContain("Overall LGTM but please add tests.");
+  });
+
+  test("formats mixed review and issue comments", () => {
+    const reviewComments: PRReviewComment[] = [
+      { user: { login: "alice" }, body: "Inline note.", path: "src/foo.ts", line: 10 },
+    ];
+    const issueComments: PRIssueComment[] = [
+      { user: { login: "bob" }, body: "General comment." },
+    ];
+    const result = formatPRComments(reviewComments, issueComments);
+    expect(result).toContain("[Review by @alice on src/foo.ts line 10]");
+    expect(result).toContain("[Comment by @bob]");
+  });
+
+  test("skips comments with empty body", () => {
+    const reviewComments: PRReviewComment[] = [
+      { user: { login: "alice" }, body: "" },
+      { user: { login: "bob" }, body: "Keep this." },
+    ];
+    const result = formatPRComments(reviewComments, []);
+    expect(result).not.toContain("@alice");
+    expect(result).toContain("@bob");
+  });
+
+  test("trims whitespace from comment bodies", () => {
+    const reviewComments: PRReviewComment[] = [
+      { user: { login: "alice" }, body: "  spaced out  " },
+    ];
+    const result = formatPRComments(reviewComments, []);
+    expect(result).toContain("spaced out");
+    expect(result).not.toContain("  spaced out  ");
+  });
+});
+
+// ── fetchPRComments ───────────────────────────────────────────────────
+
+describe("fetchPRComments", () => {
+  const prUrl = "https://github.com/acme/myrepo/pull/7";
+
+  function makeRunner(responses: Record<string, { exitCode: number; stdout: string }>): GhApiRunner {
+    return async (endpoint) => responses[endpoint] ?? { exitCode: 1, stdout: "" };
+  }
+
+  test("returns null when both API calls fail", async () => {
+    const runner = makeRunner({});
+    const result = await fetchPRComments(prUrl, runner);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when both API calls return empty arrays", async () => {
+    const runner = makeRunner({
+      "/repos/acme/myrepo/pulls/7/comments": { exitCode: 0, stdout: "[]" },
+      "/repos/acme/myrepo/issues/7/comments": { exitCode: 0, stdout: "[]" },
+    });
+    const result = await fetchPRComments(prUrl, runner);
+    expect(result).toBeNull();
+  });
+
+  test("returns formatted string when review comments exist", async () => {
+    const reviewComments: PRReviewComment[] = [
+      { user: { login: "alice" }, body: "Null check needed.", path: "src/auth.ts", line: 5 },
+    ];
+    const runner = makeRunner({
+      "/repos/acme/myrepo/pulls/7/comments": { exitCode: 0, stdout: JSON.stringify(reviewComments) },
+      "/repos/acme/myrepo/issues/7/comments": { exitCode: 0, stdout: "[]" },
+    });
+    const result = await fetchPRComments(prUrl, runner);
+    expect(result).not.toBeNull();
+    expect(result).toContain("[Review by @alice on src/auth.ts line 5]");
+    expect(result).toContain("Null check needed.");
+  });
+
+  test("returns formatted string when issue comments exist", async () => {
+    const issueComments: PRIssueComment[] = [
+      { user: { login: "bob" }, body: "Please add tests." },
+    ];
+    const runner = makeRunner({
+      "/repos/acme/myrepo/pulls/7/comments": { exitCode: 0, stdout: "[]" },
+      "/repos/acme/myrepo/issues/7/comments": { exitCode: 0, stdout: JSON.stringify(issueComments) },
+    });
+    const result = await fetchPRComments(prUrl, runner);
+    expect(result).not.toBeNull();
+    expect(result).toContain("[Comment by @bob]");
+    expect(result).toContain("Please add tests.");
+  });
+
+  test("gracefully handles malformed JSON from API", async () => {
+    const runner = makeRunner({
+      "/repos/acme/myrepo/pulls/7/comments": { exitCode: 0, stdout: "not json" },
+      "/repos/acme/myrepo/issues/7/comments": { exitCode: 0, stdout: "[]" },
+    });
+    const result = await fetchPRComments(prUrl, runner);
+    expect(result).toBeNull();
+  });
+
+  test("parses owner/repo/number correctly from URL", async () => {
+    const calls: string[] = [];
+    const runner: GhApiRunner = async (endpoint) => {
+      calls.push(endpoint);
+      return { exitCode: 0, stdout: "[]" };
+    };
+    await fetchPRComments("https://github.com/my-org/cool-repo/pull/99", runner);
+    expect(calls).toContain("/repos/my-org/cool-repo/pulls/99/comments");
+    expect(calls).toContain("/repos/my-org/cool-repo/issues/99/comments");
+  });
+});


### PR DESCRIPTION
## Summary

When a session is started `--from` a pull request URL, deer now fetches all review and issue-level comments from that PR via the GitHub API and prepends them as context to Claude's prompt. This gives the agent awareness of reviewer feedback without manual copy-paste.

## Changes

- `packages/deerbox/src/pr-comments.ts`: New module with `fetchPRComments` and `formatPRComments` functions, plus exported types (`PRReviewComment`, `PRIssueComment`, `GhApiRunner`) for injectable testing
- `packages/deerbox/src/cli.ts`: Calls `fetchPRComments` after `--from` resolves to a PR URL and prepends the formatted comments to `effectivePrompt`
- `packages/deerbox/src/index.ts`: Re-exports the new `pr-comments` module functions and types from the package public API
- `test/pr-comments.test.ts`: Full test suite covering formatting edge cases (empty bodies, whitespace, missing line numbers) and fetch behaviour (API failures, malformed JSON, URL parsing)

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.