### PR TITLE
🦌 Fix optional chaining for SRT version lookup

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -14,7 +14,7 @@ const pkg = require("../package.json");
 const REPO = "zdavison/deer";
 const VERSION = pkg.version;
 const SRT_PACKAGE = "@anthropic-ai/sandbox-runtime";
-const SRT_VERSION = pkg.dependencies[SRT_PACKAGE] ?? "latest";
+const SRT_VERSION = pkg.dependencies?.[SRT_PACKAGE] ?? "latest";
 
 const PLATFORM_MAP = {
   linux: "linux",


### PR DESCRIPTION
## Summary

Adds optional chaining when accessing `pkg.dependencies` to safely handle cases where the `dependencies` field may be absent in `package.json`.

## Changes

- `scripts/install.js`: Use optional chaining (`?.`) when reading `pkg.dependencies[SRT_PACKAGE]` to avoid a runtime error if `dependencies` is undefined

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.