### PR TITLE
🦌 Use native JSON import assertion in install script

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,15 +1,10 @@
 #!/usr/bin/env node
 
 import { writeFile, chmod, mkdir } from "fs/promises";
-import { join, dirname } from "path";
+import { join } from "path";
 import { homedir, platform, arch } from "os";
-import { createRequire } from "module";
-import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
-const pkg = require("../package.json");
+import pkg from "../package.json" with { type: "json" };
 
 const REPO = "zdavison/deer";
 const VERSION = pkg.version;


### PR DESCRIPTION
## Summary

Updates the install script to use the native ES module JSON import syntax (`import ... with { type: "json" }`) instead of the CommonJS-style `createRequire` workaround. This simplifies the code by removing several now-unnecessary imports and the manual `__dirname` polyfill.

## Changes

- `scripts/install.js`: Replace `createRequire`/`fileURLToPath`-based `package.json` loading with a direct JSON import assertion; remove unused `dirname`, `createRequire`, `fileURLToPath` imports and the `__dirname` shim

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.