### PR TITLE
🦌 Skip PR title/body update when not the PR author

### DIFF
--- a/packages/deerbox/src/git/finalize.ts
+++ b/packages/deerbox/src/git/finalize.ts
@@ -8,6 +8,8 @@ export {
   ensureDeerEmojiPrefix,
   parsePRMetadataResponse,
   buildClaudeSubprocessEnv,
+  isPRAuthorFromLogins,
+  isPRAuthor,
 } from "@deer/shared";
 export type {
   CreatePRResult,

--- a/packages/deerbox/src/index.ts
+++ b/packages/deerbox/src/index.ts
@@ -35,6 +35,8 @@ export {
   ensureDeerEmojiPrefix,
   parsePRMetadataResponse,
   buildClaudeSubprocessEnv,
+  isPRAuthorFromLogins,
+  isPRAuthor,
 } from "./git/finalize";
 export type {
   CreatePRResult,

--- a/packages/shared/src/git/finalize.ts
+++ b/packages/shared/src/git/finalize.ts
@@ -108,6 +108,12 @@ export interface UpdatePROptions {
   prUrl: string;
   /** Verbose log callback for diagnostics */
   onLog?: (message: string) => void;
+  /**
+   * Override for PR authorship check. Defaults to querying the GitHub API.
+   * Inject a mock in tests to control whether the title/body update is skipped.
+   * @default isPRAuthor
+   */
+  prAuthorCheck?: (prUrl: string, repoPath: string) => Promise<boolean>;
 }
 
 interface PRMetadata {
@@ -474,6 +480,35 @@ export async function pushBranchUpdates(options: PushBranchOptions): Promise<voi
 }
 
 /**
+ * Returns true if the two GitHub login strings refer to the same user.
+ * Defaults to true (can update) when either login is unknown/empty, so a
+ * gh API failure doesn't silently block pushes.
+ */
+export function isPRAuthorFromLogins(currentLogin: string, authorLogin: string): boolean {
+  if (!currentLogin || !authorLogin) return true;
+  return currentLogin === authorLogin;
+}
+
+/**
+ * Returns true if the authenticated GitHub user is the author of the given PR.
+ * Defaults to true on any gh API error so that failed lookups don't block pushes.
+ */
+export async function isPRAuthor(prUrl: string, repoPath: string): Promise<boolean> {
+  const prMatch = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!prMatch) return true;
+  const [, owner, repo, prNumber] = prMatch;
+
+  const [currentUserResult, prAuthorResult] = await Promise.all([
+    Bun.$`gh api user --jq .login`.cwd(repoPath).quiet().nothrow(),
+    Bun.$`gh api repos/${owner}/${repo}/pulls/${prNumber} --jq .user.login`.cwd(repoPath).quiet().nothrow(),
+  ]);
+
+  const currentLogin = currentUserResult.stdout.toString().trim();
+  const authorLogin = prAuthorResult.stdout.toString().trim();
+  return isPRAuthorFromLogins(currentLogin, authorLogin);
+}
+
+/**
  * Update an existing PR: commit any new changes, push, and regenerate the
  * PR title and body from the latest diff.
  */
@@ -509,6 +544,16 @@ export async function updatePullRequest(options: UpdatePROptions): Promise<void>
   log(`[pr] Pushing branch ${finalBranch}...`);
   await pushBranch(worktreePath, finalBranch);
   log(`[pr] Push succeeded`);
+
+  // Only update title/body if we own the PR — GitHub silently ignores PATCH
+  // requests on PRs authored by other users when called by a non-admin.
+  const checkAuthor = options.prAuthorCheck ?? isPRAuthor;
+  const isAuthor = await checkAuthor(prUrl, repoPath);
+
+  if (!isAuthor) {
+    log(`[pr] Skipping PR title/body update: PR was authored by a different user`);
+    return;
+  }
 
   // Update the PR title and body via REST API to avoid deprecated projectCards GraphQL query
   const prMatch = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,8 @@ export {
   ensureDeerEmojiPrefix,
   parsePRMetadataResponse,
   buildClaudeSubprocessEnv,
+  isPRAuthorFromLogins,
+  isPRAuthor,
 } from "./git/finalize";
 export type {
   CreatePRResult,

--- a/test/finalize.test.ts
+++ b/test/finalize.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { ensureDeerEmojiPrefix, findPRTemplate, parsePRMetadataResponse, buildClaudeSubprocessEnv } from "deerbox";
+import { ensureDeerEmojiPrefix, findPRTemplate, parsePRMetadataResponse, buildClaudeSubprocessEnv, isPRAuthorFromLogins } from "deerbox";
 
 describe("ensureDeerEmojiPrefix", () => {
   test("adds deer emoji to plain title", () => {
@@ -216,5 +216,31 @@ describe("buildClaudeSubprocessEnv", () => {
     const env = buildClaudeSubprocessEnv({ DEFINED: "yes", UNDEFINED: undefined } as Record<string, string | undefined>);
     expect(env.DEFINED).toBe("yes");
     expect("UNDEFINED" in env).toBe(false);
+  });
+});
+
+describe("isPRAuthorFromLogins", () => {
+  test("returns true when logins match", () => {
+    expect(isPRAuthorFromLogins("alice", "alice")).toBe(true);
+  });
+
+  test("returns false when logins differ", () => {
+    expect(isPRAuthorFromLogins("alice", "bob")).toBe(false);
+  });
+
+  test("returns true when current user login is unknown (empty string)", () => {
+    expect(isPRAuthorFromLogins("", "alice")).toBe(true);
+  });
+
+  test("returns true when PR author login is unknown (empty string)", () => {
+    expect(isPRAuthorFromLogins("alice", "")).toBe(true);
+  });
+
+  test("returns true when both logins are empty", () => {
+    expect(isPRAuthorFromLogins("", "")).toBe(true);
+  });
+
+  test("is case-sensitive", () => {
+    expect(isPRAuthorFromLogins("Alice", "alice")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds authorship checking before updating a PR's title and body. GitHub silently ignores PATCH requests on PRs authored by other users when called by a non-admin, so deer now detects this case and skips the update step rather than silently failing.

When the `gh` API is unavailable or returns an empty login, the check defaults to `true` (allow update) so that API failures don't block pushes.

## Changes

- `packages/shared/src/git/finalize.ts`: Added `isPRAuthorFromLogins` (pure login comparison) and `isPRAuthor` (GitHub API lookup), plus an optional `prAuthorCheck` injection point on `UpdatePROptions`; `updatePullRequest` now calls the check and returns early if the current user is not the PR author
- `packages/shared/src/index.ts`: Exports `isPRAuthorFromLogins` and `isPRAuthor`
- `packages/deerbox/src/git/finalize.ts`: Re-exports `isPRAuthorFromLogins` and `isPRAuthor` from `@deer/shared`
- `packages/deerbox/src/index.ts`: Re-exports `isPRAuthorFromLogins` and `isPRAuthor` from the local finalize module
- `test/finalize.test.ts`: Adds a `isPRAuthorFromLogins` describe block covering matching logins, differing logins, empty/unknown logins, and case-sensitivity

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.