### PR TITLE
fix: candidatePath var for candidatePaths loop

### DIFF
--- a/packages/shared/src/credentials.ts
+++ b/packages/shared/src/credentials.ts
@@ -68,9 +68,9 @@ export async function resolveCredentials(
       join(homeDir, ".config", "claude", "config.json"),
       join(homeDir, ".claude", ".credentials.json"),
     ];
-    for (const p of candidatePaths) {
+    for (const candidatePath of candidatePaths) {
       try {
-        const token = JSON.parse(await Bun.file(p).text())?.claudeAiOauth?.accessToken;
+        const token = JSON.parse(await Bun.file(candidatePath).text())?.claudeAiOauth?.accessToken;
         if (typeof token === "string" && token.length > 0) {
           process.env.CLAUDE_CODE_OAUTH_TOKEN = token;
           break;


### PR DESCRIPTION
Fixes invalid variable for `candidatePaths` loop