### PR TITLE
fix: allow npm/pnpm toolchain paths in sandbox

### DIFF
--- a/packages/deerbox/src/ecosystems.ts
+++ b/packages/deerbox/src/ecosystems.ts
@@ -56,6 +56,7 @@ const pnpmPlugin: EcosystemPlugin = {
   name: "pnpm",
   detect: async (repoPath) => pathExists(join(repoPath, "pnpm-lock.yaml")),
   strategies: [
+    { type: "readonly-cache", hostPath: "~/.pnpm-store" },
     { type: "prepopulate", source: "node_modules", lockfile: "pnpm-lock.yaml" },
     { type: "env", vars: { PNPM_HOME: ".pnpm-store" } },
   ],
@@ -73,6 +74,7 @@ const npmPlugin: EcosystemPlugin = {
     return hasPackageLock && !hasPnpmLock && !hasBunLock && !hasBunLockb;
   },
   strategies: [
+    { type: "readonly-cache", hostPath: "~/.npm" },
     { type: "prepopulate", source: "node_modules", lockfile: "package-lock.json" },
   ],
 };

--- a/packages/deerbox/src/sandbox/srt.ts
+++ b/packages/deerbox/src/sandbox/srt.ts
@@ -151,6 +151,7 @@ function buildSrtSettings(options: SandboxRuntimeOptions, srtBinDir: string | nu
     ...(options.repoGitDir ? [options.repoGitDir] : []),
     ...(process.env.PATH?.split(":").filter((p) => p.startsWith(HOME)) ?? []),
     ...(srtBinDir ? [srtBinDir] : []),
+    ...(options.extraReadPaths ?? []),
   ];
 
   // Deny read access to all HOME entries except .claude* and required roots.

--- a/test/ecosystems/npm.test.ts
+++ b/test/ecosystems/npm.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Verify the npm ecosystem plugin allows the sandbox to read
+ * Node.js toolchain paths required for `npm install`.
+ *
+ * Issue: https://github.com/zdavison/deer/issues/192
+ */
+import { test, expect, describe, afterEach } from "bun:test";
+import { createSrtRuntime, BUILTIN_PLUGINS, applyEcosystems } from "../../packages/deerbox/src/index";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const HOME = process.env.HOME!;
+
+describe("npm ecosystem - sandbox toolchain paths (issue #192)", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of tmpDirs.splice(0)) {
+      await rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "deer-npm-test-"));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  const npmPlugin = BUILTIN_PLUGINS.find((p) => p.name === "npm")!;
+
+  test("npm plugin declares readonly-cache for ~/.npm", async () => {
+    const hasCacheStrategy = npmPlugin.strategies.some(
+      (s) => s.type === "readonly-cache" && s.hostPath === "~/.npm",
+    );
+    expect(hasCacheStrategy).toBe(true);
+  });
+
+  test("npm ecosystem produces extraReadPaths for ~/.npm", async () => {
+    const repoPath = await makeTmpDir();
+    const worktreePath = await makeTmpDir();
+    await writeFile(join(repoPath, "package-lock.json"), "{}");
+
+    const result = await applyEcosystems(repoPath, worktreePath);
+    expect(result.extraReadPaths).toContain(join(HOME, ".npm"));
+  });
+
+  test("~/.npm is excluded from sandbox denyRead when npm ecosystem active", async () => {
+    const worktreeDir = await makeTmpDir();
+    const repoGitDir = await makeTmpDir();
+    const worktreeGitDir = join(repoGitDir, "worktrees", "task1");
+    await mkdir(worktreeGitDir, { recursive: true });
+    await mkdir(join(repoGitDir, "objects"), { recursive: true });
+    await mkdir(join(repoGitDir, "refs"), { recursive: true });
+    await writeFile(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+
+    const npmCachePath = join(HOME, ".npm");
+
+    const runtime = createSrtRuntime();
+    await runtime.prepare?.({
+      worktreePath: worktreeDir,
+      repoGitDir,
+      allowlist: [],
+      extraReadPaths: [npmCachePath],
+    });
+
+    const settingsPath = join(worktreeDir, "..", "srt-settings.json");
+    const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+    const denyRead: string[] = settings.filesystem.denyRead;
+
+    if (existsSync(npmCachePath)) {
+      expect(denyRead).not.toContain(npmCachePath);
+    }
+  });
+});

--- a/test/ecosystems/pnpm.test.ts
+++ b/test/ecosystems/pnpm.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Verify the pnpm ecosystem plugin allows the sandbox to read
+ * Node.js toolchain paths required for `pnpm install`.
+ *
+ * Issue: https://github.com/zdavison/deer/issues/192
+ */
+import { test, expect, describe, afterEach } from "bun:test";
+import { createSrtRuntime, BUILTIN_PLUGINS, applyEcosystems } from "../../packages/deerbox/src/index";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const HOME = process.env.HOME!;
+
+describe("pnpm ecosystem - sandbox toolchain paths (issue #192)", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of tmpDirs.splice(0)) {
+      await rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "deer-pnpm-test-"));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  const pnpmPlugin = BUILTIN_PLUGINS.find((p) => p.name === "pnpm")!;
+
+  test("pnpm plugin declares readonly-cache for ~/.pnpm-store", async () => {
+    const hasCacheStrategy = pnpmPlugin.strategies.some(
+      (s) => s.type === "readonly-cache" && s.hostPath === "~/.pnpm-store",
+    );
+    expect(hasCacheStrategy).toBe(true);
+  });
+
+  test("pnpm ecosystem produces extraReadPaths for ~/.pnpm-store", async () => {
+    const repoPath = await makeTmpDir();
+    const worktreePath = await makeTmpDir();
+    await writeFile(join(repoPath, "pnpm-lock.yaml"), "lockfileVersion: '9.0'");
+
+    const result = await applyEcosystems(repoPath, worktreePath);
+    expect(result.extraReadPaths).toContain(join(HOME, ".pnpm-store"));
+  });
+
+  test("~/.pnpm-store is excluded from sandbox denyRead when pnpm ecosystem active", async () => {
+    const worktreeDir = await makeTmpDir();
+    const repoGitDir = await makeTmpDir();
+    const worktreeGitDir = join(repoGitDir, "worktrees", "task1");
+    await mkdir(worktreeGitDir, { recursive: true });
+    await mkdir(join(repoGitDir, "objects"), { recursive: true });
+    await mkdir(join(repoGitDir, "refs"), { recursive: true });
+    await writeFile(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+
+    const pnpmStorePath = join(HOME, ".pnpm-store");
+
+    const runtime = createSrtRuntime();
+    await runtime.prepare?.({
+      worktreePath: worktreeDir,
+      repoGitDir,
+      allowlist: [],
+      extraReadPaths: [pnpmStorePath],
+    });
+
+    const settingsPath = join(worktreeDir, "..", "srt-settings.json");
+    const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+    const denyRead: string[] = settings.filesystem.denyRead;
+
+    if (existsSync(pnpmStorePath)) {
+      expect(denyRead).not.toContain(pnpmStorePath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #192

- Add `readonly-cache` strategies to npm (`~/.npm`) and pnpm (`~/.pnpm-store`) ecosystem plugins so they declare the host cache paths they need
- Wire `options.extraReadPaths` into `buildHomeDenyList` in `srt.ts` — this field was already plumbed through `session.ts` but never consumed by the SRT settings builder, so ecosystem-declared cache paths were silently ignored
- Add `test/ecosystems/npm.test.ts` and `test/ecosystems/pnpm.test.ts` verifying the fix end-to-end

## Test plan

- [x] `bun test test/ecosystems/` — new npm/pnpm tests pass
- [x] `bun test test/sandbox/srt-settings.test.ts` — existing SRT tests still pass
- [x] `bun test test/ecosystems.test.ts` — existing ecosystem tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)