### PR TITLE
🦌 Block sibling task directories in SRT sandbox

### DIFF
--- a/packages/deerbox/src/sandbox/srt.ts
+++ b/packages/deerbox/src/sandbox/srt.ts
@@ -202,12 +202,20 @@ function buildSrtSettings(options: SandboxRuntimeOptions, srtBinDir: string | nu
     // tokens — all auth is handled by the host-side MITM proxy.
     join(claudeDir, ".credentials.json"),
     join(claudeDir, "agent-oauth-token"),
+    // Block all sibling task directories. The tasks root (parent of the task
+    // dir) is readable via .local, so we must explicitly deny it and then
+    // re-allow only this task's own directory via allowRead below.
+    dirname(dirname(options.worktreePath)),
   ];
+
+  // Re-allow only this task's own directory within the denied tasks root.
+  const allowRead = [dirname(options.worktreePath)];
 
   return {
     network,
     filesystem: {
       denyRead,
+      allowRead,
       allowWrite: [
         options.worktreePath,
         // Per-worktree gitdir (.git/worktrees/<name>/) and shared git

--- a/test/sandbox/srt-settings.test.ts
+++ b/test/sandbox/srt-settings.test.ts
@@ -93,6 +93,52 @@ describe("srt settings - git write permissions", () => {
   });
 });
 
+describe("srt settings - cross-task isolation", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of tmpDirs.splice(0)) {
+      await rm(d, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "deer-srt-isolation-"));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  test("sibling task directories are blocked via denyRead/allowRead", async () => {
+    // tasks/
+    //   current-task/worktree/   <- this task
+    //   sibling-task/worktree/   <- must not be readable
+    const tasksRoot = await makeTmpDir();
+    const currentTaskDir = join(tasksRoot, "current-task");
+    const siblingTaskDir = join(tasksRoot, "sibling-task");
+    const worktreeDir = join(currentTaskDir, "worktree");
+    await mkdir(worktreeDir, { recursive: true });
+    await mkdir(join(siblingTaskDir, "worktree"), { recursive: true });
+
+    const runtime = createSrtRuntime();
+    await runtime.prepare?.({
+      worktreePath: worktreeDir,
+      allowlist: [],
+    });
+
+    const settingsPath = join(currentTaskDir, "srt-settings.json");
+    const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+    const denyRead: string[] = settings.filesystem.denyRead;
+    const allowRead: string[] = settings.filesystem.allowRead;
+
+    // The tasks root must be denied to block sibling tasks
+    expect(denyRead).toContain(tasksRoot);
+    // The current task dir must be re-allowed
+    expect(allowRead).toContain(currentTaskDir);
+    // Sibling task dir must not appear in allowRead
+    expect(allowRead).not.toContain(siblingTaskDir);
+  });
+});
+
 describe("resolveSymlinkTargets", () => {
   const tmpDirs: string[] = [];
 


### PR DESCRIPTION
## Summary

Fixes a sandbox isolation gap where a task agent could read sibling task directories. The tasks root directory (parent of the current task dir) was accessible via `.local`, allowing traversal into other tasks' worktrees. This change explicitly denies the tasks root in `denyRead`, then re-allows only the current task's own directory via `allowRead`.

## Changes

- `packages/deerbox/src/sandbox/srt.ts`: Add `dirname(dirname(options.worktreePath))` (the tasks root) to `denyRead`, and add `allowRead` list containing only `dirname(options.worktreePath)` (the current task dir) to restore access
- `test/sandbox/srt-settings.test.ts`: Add `srt settings - cross-task isolation` test suite verifying that the tasks root is denied, the current task dir is re-allowed, and sibling task dirs do not appear in `allowRead`

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.