### PR TITLE
Fix macOS binaries killed on launch (exit 137)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
         required: true
 
 jobs:
-  build:
-    name: Build binaries
+  build-linux:
+    name: Build Linux binaries
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,7 +27,6 @@ jobs:
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"
-          # Update all workspace package.json versions to match the release tag
           for pkg in package.json packages/*/package.json; do
             jq --arg v "$VERSION" '.version = $v' "$pkg" > "$pkg.tmp" && mv "$pkg.tmp" "$pkg"
           done
@@ -38,14 +37,74 @@ jobs:
       - name: Build binaries
         run: |
           mkdir -p dist
-          bun build --compile --target=bun-linux-x64    src/cli.tsx              --outfile dist/deer-linux-x64
-          bun build --compile --target=bun-linux-arm64   src/cli.tsx              --outfile dist/deer-linux-arm64
-          bun build --compile --target=bun-darwin-x64   src/cli.tsx              --outfile dist/deer-darwin-x64
-          bun build --compile --target=bun-darwin-arm64  src/cli.tsx              --outfile dist/deer-darwin-arm64
-          bun build --compile --target=bun-linux-x64    packages/deerbox/src/cli.ts --outfile dist/deerbox-linux-x64
-          bun build --compile --target=bun-linux-arm64   packages/deerbox/src/cli.ts --outfile dist/deerbox-linux-arm64
-          bun build --compile --target=bun-darwin-x64   packages/deerbox/src/cli.ts --outfile dist/deerbox-darwin-x64
-          bun build --compile --target=bun-darwin-arm64  packages/deerbox/src/cli.ts --outfile dist/deerbox-darwin-arm64
+          bun build --compile --target=bun-linux-x64    src/cli.tsx                  --outfile dist/deer-linux-x64
+          bun build --compile --target=bun-linux-arm64   src/cli.tsx                  --outfile dist/deer-linux-arm64
+          bun build --compile --target=bun-linux-x64    packages/deerbox/src/cli.ts   --outfile dist/deerbox-linux-x64
+          bun build --compile --target=bun-linux-arm64   packages/deerbox/src/cli.ts   --outfile dist/deerbox-linux-arm64
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-binaries
+          path: dist/*
+
+  build-macos:
+    name: Build macOS binaries
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Set version from tag
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          for pkg in package.json packages/*/package.json; do
+            jq --arg v "$VERSION" '.version = $v' "$pkg" > "$pkg.tmp" && mv "$pkg.tmp" "$pkg"
+          done
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist
+          bun build --compile --target=bun-darwin-x64    src/cli.tsx                  --outfile dist/deer-darwin-x64
+          bun build --compile --target=bun-darwin-arm64   src/cli.tsx                  --outfile dist/deer-darwin-arm64
+          bun build --compile --target=bun-darwin-x64    packages/deerbox/src/cli.ts   --outfile dist/deerbox-darwin-x64
+          bun build --compile --target=bun-darwin-arm64   packages/deerbox/src/cli.ts   --outfile dist/deerbox-darwin-arm64
+
+      - name: Ad-hoc codesign macOS binaries
+        run: |
+          for bin in dist/*-darwin-*; do
+            codesign --force --sign - "$bin"
+          done
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-binaries
+          path: dist/*
+
+  release:
+    name: Create release
+    needs: [build-linux, build-macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Verify binaries
         run: ls -lh dist/
@@ -62,7 +121,7 @@ jobs:
 
   deploy-docs:
     name: Deploy docs to GitHub Pages
-    needs: build
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/packages/shared/src/updater.ts
+++ b/packages/shared/src/updater.ts
@@ -99,6 +99,10 @@ export async function checkAndUpdate({ name, version }: UpdateOptions): Promise<
   try {
     await Bun.write(tmpPath, data);
     await Bun.$`chmod +x ${tmpPath}`.quiet();
+    // macOS requires ad-hoc codesigning for binaries to execute
+    if (process.platform === "darwin") {
+      await Bun.$`codesign --force --sign - ${tmpPath}`.quiet();
+    }
     await Bun.$`mv ${tmpPath} ${currentPath}`.quiet();
   } catch {
     await Bun.$`rm -f ${tmpPath}`.quiet();


### PR DESCRIPTION
## Summary

- **Release workflow**: macOS binaries were cross-compiled on Linux, producing Mach-O executables with an invalid format that macOS cannot codesign or execute. The kernel immediately SIGKILLs them (exit 137). Split the build into `build-linux` (ubuntu-latest) and `build-macos` (macos-latest) jobs so macOS binaries are compiled natively and ad-hoc codesigned in CI.
- **Auto-updater**: Downloaded binaries were not codesigned on macOS, so even if the initial install worked, auto-updates would break the binary. Added `codesign --force --sign -` before replacing the current binary.

## Test plan

- [x] Built deer + deerbox locally on macOS, codesigned, and verified both run (`--version` returns correctly)
- [x] Confirmed the currently-installed binaries from the latest release exit 137 and fail codesign (`code object is not signed at all`)
- [ ] Trigger a release build and verify macOS binaries from the GitHub release work on a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)