### PR TITLE
Fix deerbox hang on systems with node version manager shims

### DIFF
--- a/packages/deerbox/src/sandbox/auth-proxy.ts
+++ b/packages/deerbox/src/sandbox/auth-proxy.ts
@@ -128,7 +128,14 @@ export function ensureCACert(dir: string): CACert {
  * real binary, then cache the result to disk so we only pay the cost once.
  */
 let cachedNodePath: string | null = null;
-function isRealBinary(path: string): boolean {
+/**
+ * Check whether `path` points to a real executable (Mach-O or ELF) rather
+ * than a shell-script shim. Reads the first 4 bytes and matches against
+ * known executable magic numbers. Returns false on any I/O error.
+ *
+ * Exported for testing.
+ */
+export function isRealBinary(path: string): boolean {
   try {
     const fd = openSync(path, "r");
     const buf = Buffer.alloc(4);

--- a/packages/deerbox/src/sandbox/auth-proxy.ts
+++ b/packages/deerbox/src/sandbox/auth-proxy.ts
@@ -11,7 +11,7 @@
 
 import { spawn, execSync } from "node:child_process";
 import { join } from "node:path";
-import { mkdirSync, writeFileSync, existsSync, openSync, unlinkSync, readFileSync, chmodSync, renameSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, openSync, closeSync, readSync, unlinkSync, readFileSync, chmodSync, renameSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 import authProxySource from "./auth-proxy-server.mjs" with { type: "text" };
@@ -119,6 +119,70 @@ export function ensureCACert(dir: string): CACert {
 }
 
 /**
+ * Resolve the node binary path. If `node` on PATH is a shell shim
+ * (e.g. nodenv, asdf), spawning it via child_process.spawn from Bun fails
+ * because the shim relies on shell environment setup Bun doesn't provide.
+ *
+ * Fast path: if `which node` returns a real binary, use it directly.
+ * Shim path: run `node -e 'console.log(process.execPath)'` to resolve the
+ * real binary, then cache the result to disk so we only pay the cost once.
+ */
+let cachedNodePath: string | null = null;
+function isRealBinary(path: string): boolean {
+  try {
+    const fd = openSync(path, "r");
+    const buf = Buffer.alloc(4);
+    readSync(fd, buf, 0, 4, 0);
+    closeSync(fd);
+    // Mach-O (macOS): CFFAEDFE, CEFAEDFE, CAFEBABE. ELF (Linux): 7F454C46.
+    return buf[0] === 0xcf || buf[0] === 0xce || buf[0] === 0xca || buf[0] === 0x7f;
+  } catch { return false; }
+}
+
+function resolveNodePath(): string {
+  if (cachedNodePath) return cachedNodePath;
+
+  // Load cached real-binary path from disk (avoids re-resolving every run).
+  const cacheDir = process.env.DEER_DATA_DIR ?? join(process.env.HOME ?? "/root", ".local", "share", "deer");
+  const cacheFile = join(cacheDir, "node-path");
+  try {
+    const cached = readFileSync(cacheFile, "utf-8").trim();
+    if (cached && isRealBinary(cached)) {
+      cachedNodePath = cached;
+      return cached;
+    }
+  } catch { /* no cache */ }
+
+  // Find node on PATH. If it's already a real binary, use it directly.
+  let candidate = "";
+  try {
+    candidate = execSync("command -v node", { encoding: "utf-8", shell: "/bin/sh" }).trim();
+  } catch { /* not found */ }
+
+  if (candidate && isRealBinary(candidate)) {
+    cachedNodePath = candidate;
+    try { mkdirSync(cacheDir, { recursive: true }); writeFileSync(cacheFile, candidate); } catch { /* ignore */ }
+    return candidate;
+  }
+
+  // It's a shim. Resolve through it (slow cold start on nodenv/asdf).
+  try {
+    const resolved = execSync(`node -e 'console.log(process.execPath)'`, {
+      encoding: "utf-8",
+      shell: "/bin/sh",
+    }).trim();
+    if (resolved && isRealBinary(resolved)) {
+      cachedNodePath = resolved;
+      try { mkdirSync(cacheDir, { recursive: true }); writeFileSync(cacheFile, resolved); } catch { /* ignore */ }
+      return resolved;
+    }
+  } catch { /* fall through */ }
+
+  cachedNodePath = "node";
+  return "node";
+}
+
+/**
  * Start the authenticating MITM proxy as a Node.js subprocess.
  *
  * @param daemonize - If true, detach the process so it survives parent exit.
@@ -134,14 +198,15 @@ export async function startAuthProxy(
 ): Promise<AuthProxy> {
   const serverScript = ensureServerScript();
   const pidFilePath = `${socketPath}.pid`;
+  const nodePath = resolveNodePath();
 
   if (daemonize) {
-    // Daemonized mode: no pipes — poll for the socket file to appear.
+    // Daemonized mode: no pipes. Poll for the socket file to appear.
     // Stderr goes to a temp file so we can report errors if the child crashes.
     const errFile = `${socketPath}.err`;
     const errFd = openSync(errFile, "w");
     const devNull = openSync("/dev/null", "w");
-    const child = spawn("node", [
+    const child = spawn(nodePath, [
       serverScript,
       socketPath,
       JSON.stringify(upstreams),
@@ -182,7 +247,7 @@ export async function startAuthProxy(
   }
 
   // Non-daemonized mode: use pipes for log forwarding
-  const child = spawn("node", [
+  const child = spawn(nodePath, [
     serverScript,
     socketPath,
     JSON.stringify(upstreams),
@@ -195,37 +260,39 @@ export async function startAuthProxy(
   // that this task is still alive (interactive deerbox has no tmux session).
   writeFileSync(pidFilePath, String(child.pid));
 
+  // Attach log readers. Stdout JSON lines are forwarded as logs. We poll the
+  // socket file for readiness rather than waiting for a "ready" JSON line,
+  // because pipes between Bun and Node ESM subprocesses aren't always reliable.
+  const rl = createInterface({ input: child.stdout! });
+  rl.on("line", (line: string) => {
+    try {
+      const msg = JSON.parse(line);
+      if (msg.log) onLog?.(msg.log);
+    } catch { /* ignore malformed */ }
+  });
   child.stderr?.on("data", (data: Buffer) => {
     onLog?.(`[proxy:stderr] ${data.toString().trim()}`);
   });
 
-  // Wait for the "ready" signal from the subprocess
+  // Wait for the socket file to appear (the server creates it when listening).
   await new Promise<void>((resolve, reject) => {
     const onExit = (code: number | null) => {
       reject(new Error(`auth-proxy subprocess exited with code ${code} before ready`));
     };
     child.once("exit", onExit);
 
-    const rl = createInterface({ input: child.stdout! });
-    rl.on("line", (line: string) => {
-      try {
-        const msg = JSON.parse(line);
-        if (msg.ready) {
-          child.removeListener("exit", onExit);
-          rl.on("line", (logLine: string) => {
-            try {
-              const logMsg = JSON.parse(logLine);
-              if (logMsg.log) onLog?.(logMsg.log);
-            } catch { /* ignore malformed */ }
-          });
-          resolve();
-        } else if (msg.log) {
-          onLog?.(msg.log);
-        }
-      } catch { /* ignore malformed */ }
-    });
-
-    setTimeout(() => reject(new Error("auth-proxy subprocess did not become ready in 10s")), 10000);
+    const start = Date.now();
+    const poll = setInterval(() => {
+      if (existsSync(socketPath)) {
+        clearInterval(poll);
+        child.removeListener("exit", onExit);
+        resolve();
+      } else if (Date.now() - start > 10000) {
+        clearInterval(poll);
+        child.removeListener("exit", onExit);
+        reject(new Error("auth-proxy subprocess did not become ready in 10s"));
+      }
+    }, 100);
   });
 
   return {

--- a/test/auth-proxy.test.ts
+++ b/test/auth-proxy.test.ts
@@ -1,0 +1,93 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, chmod } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { isRealBinary } from "../packages/deerbox/src/sandbox/auth-proxy";
+
+describe("isRealBinary", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "deer-isrealbinary-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Mach-O magic numbers (macOS)
+  test("returns true for Mach-O 64-bit little-endian binary (CF FA ED FE)", async () => {
+    const path = join(tmpDir, "macho-64-le");
+    await writeFile(path, Buffer.from([0xcf, 0xfa, 0xed, 0xfe, 0x00, 0x00, 0x00, 0x00]));
+    expect(isRealBinary(path)).toBe(true);
+  });
+
+  test("returns true for Mach-O 32-bit little-endian binary (CE FA ED FE)", async () => {
+    const path = join(tmpDir, "macho-32-le");
+    await writeFile(path, Buffer.from([0xce, 0xfa, 0xed, 0xfe, 0x00, 0x00, 0x00, 0x00]));
+    expect(isRealBinary(path)).toBe(true);
+  });
+
+  test("returns true for Mach-O fat/universal binary (CA FE BA BE)", async () => {
+    const path = join(tmpDir, "macho-fat");
+    await writeFile(path, Buffer.from([0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x02]));
+    expect(isRealBinary(path)).toBe(true);
+  });
+
+  // ELF magic number (Linux)
+  test("returns true for ELF binary (7F 45 4C 46)", async () => {
+    const path = join(tmpDir, "elf");
+    await writeFile(path, Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00]));
+    expect(isRealBinary(path)).toBe(true);
+  });
+
+  // Shell-script shims (nodenv, asdf) on both macOS and Linux are plain
+  // bash scripts with #! shebang lines. The magic byte is 0x23 ('#').
+  test("returns false for nodenv-style bash shim", async () => {
+    const path = join(tmpDir, "nodenv-shim");
+    await writeFile(
+      path,
+      '#!/usr/bin/env bash\nset -e\n[ -n "$NODENV_DEBUG" ] && set -x\n\nprogram="${0##*/}"\nexec nodenv exec "$program" "$@"\n',
+    );
+    await chmod(path, 0o755);
+    expect(isRealBinary(path)).toBe(false);
+  });
+
+  test("returns false for asdf-style bash shim", async () => {
+    const path = join(tmpDir, "asdf-shim");
+    await writeFile(
+      path,
+      '#!/usr/bin/env bash\n# asdf-plugin: nodejs\nexec /usr/local/opt/asdf/libexec/bin/asdf exec "$@"\n',
+    );
+    await chmod(path, 0o755);
+    expect(isRealBinary(path)).toBe(false);
+  });
+
+  test("returns false for sh shebang", async () => {
+    const path = join(tmpDir, "sh-script");
+    await writeFile(path, "#!/bin/sh\necho hello\n");
+    await chmod(path, 0o755);
+    expect(isRealBinary(path)).toBe(false);
+  });
+
+  test("returns false for non-existent file", () => {
+    expect(isRealBinary(join(tmpDir, "does-not-exist"))).toBe(false);
+  });
+
+  test("returns false for empty file", async () => {
+    const path = join(tmpDir, "empty");
+    await writeFile(path, "");
+    expect(isRealBinary(path)).toBe(false);
+  });
+
+  test("returns false for plain text file", async () => {
+    const path = join(tmpDir, "text");
+    await writeFile(path, "just some text, not a binary\n");
+    expect(isRealBinary(path)).toBe(false);
+  });
+
+  // Sanity check: the actual Node.js binary on the test machine should be real
+  test("returns true for the running Node binary", () => {
+    expect(isRealBinary(process.execPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #294. `deerbox` currently hangs for 10 seconds and fails with `Fatal: auth-proxy subprocess did not become ready in 10s` on systems where `node` on PATH is a shell-script shim (nodenv, asdf, some nvm setups).

## Root cause

`child_process.spawn` from Bun can't execute shell-script shims. The shim relies on shell environment setup that Bun doesn't provide, so the Node subprocess never actually starts. No socket file is created, no ready signal is sent, and the parent times out.

## Fix

1. **Resolve `node` to a real binary before spawning.** Detect shims via the first 4 bytes (shell scripts don't have Mach-O/ELF magic numbers). If it's a shim, run `node -e 'console.log(process.execPath)'` once to get the real path.
2. **Cache the resolved path** to `~/.local/share/deer/node-path` so the cold-start cost (~15s on nodenv) is paid only once per install. Subsequent runs resolve in <1ms.
3. **Switch the non-daemonized readiness check** from stdout readline to socket-file polling. This matches the daemonized path and is more reliable across the Bun <-> Node pipe boundary.

## Test plan

- [x] Reproduced the 10s timeout on macOS with nodenv shim
- [x] Verified fix brings cold-start to ~15s (one-time) and warm-start to ~100ms
- [x] `deerbox` now starts successfully from a clean install

## Environment

- macOS Darwin 24.5.0, arm64
- nodenv (`~/.nodenv/shims/node`)