### PR TITLE
Expose sandbox write_paths and read_paths config

### DIFF
--- a/deer.toml.example
+++ b/deer.toml.example
@@ -16,6 +16,15 @@
 # [sandbox]
 # env_passthrough_extra = ["NODE_ENV", "CI"]
 
+# Grant extra write paths inside the sandbox (e.g. for hooks that write outside the worktree).
+# Paths starting with ~ are resolved to $HOME.
+# [sandbox]
+# write_paths_extra = ["~/.my-hook-data"]
+
+# Grant extra read paths inside the sandbox (e.g. for accessing host docs or config).
+# [sandbox]
+# read_paths_extra = ["~/.my-docs"]
+
 # Disable specific ecosystem plugins (uv, pnpm, npm, go).
 # [sandbox]
 # ecosystems_disabled = ["npm"]

--- a/docs/configuration/field-reference.md
+++ b/docs/configuration/field-reference.md
@@ -44,6 +44,10 @@ api.github.com
 | `runtime` | string | `"srt"` | global | Sandbox runtime. Only `"srt"` is supported. |
 | `env_passthrough` | string[] | `[]` | global | Host env vars forwarded to the sandbox. |
 | `env_passthrough_extra` | string[] | `[]` | repo-local | Additional env vars to forward. |
+| `write_paths` | string[] | `[]` | global | Host paths to grant write access inside the sandbox. Paths starting with `~/` are resolved to `$HOME`. |
+| `write_paths_extra` | string[] | `[]` | repo-local | Additional write paths to append. |
+| `read_paths` | string[] | `[]` | global | Host paths to grant read access inside the sandbox. Paths starting with `~/` are resolved to `$HOME`. |
+| `read_paths_extra` | string[] | `[]` | repo-local | Additional read paths to append. |
 | `proxy_credentials` | ProxyCredential[] | (built-in) | global | Credentials for the MITM auth proxy. Replaces the built-in list when set. |
 | `proxy_credentials_extra` | ProxyCredential[] | `[]` | repo-local | Additional proxy credentials to append. |
 | `ecosystems_disabled` | string[] | `[]` | repo-local | Ecosystem plugins to disable (e.g. `["npm", "go"]`). |

--- a/packages/deerbox/src/config.ts
+++ b/packages/deerbox/src/config.ts
@@ -72,6 +72,18 @@ export interface DeerConfig {
      */
     proxyCredentials: ProxyCredential[];
     /**
+     * Host paths to grant read-write access inside the sandbox.
+     * Paths starting with `~/` are resolved to $HOME at session start.
+     * Useful for Claude Code hooks that write outside the worktree.
+     */
+    writePaths: string[];
+    /**
+     * Host paths to grant read access inside the sandbox.
+     * Paths starting with `~/` are resolved to $HOME at session start.
+     * Useful for accessing documentation or config files from the host.
+     */
+    readPaths: string[];
+    /**
      * Ecosystem plugin configuration.
      */
     ecosystems?: {
@@ -104,6 +116,8 @@ export const DEFAULT_CONFIG: DeerConfig = {
   sandbox: {
     runtime: "srt",
     envPassthrough: [],
+    writePaths: [],
+    readPaths: [],
     proxyCredentials: [
       {
         // No sandboxEnv — Claude Code uses https://api.anthropic.com directly.
@@ -212,6 +226,18 @@ function applyRepoLocal(config: DeerConfig, repoLocal: Record<string, unknown>):
       ...(sandbox.env_passthrough_extra as string[]),
     ];
   }
+  if (sandbox?.write_paths_extra && Array.isArray(sandbox.write_paths_extra)) {
+    result.sandbox.writePaths = [
+      ...result.sandbox.writePaths,
+      ...(sandbox.write_paths_extra as string[]),
+    ];
+  }
+  if (sandbox?.read_paths_extra && Array.isArray(sandbox.read_paths_extra)) {
+    result.sandbox.readPaths = [
+      ...result.sandbox.readPaths,
+      ...(sandbox.read_paths_extra as string[]),
+    ];
+  }
   if (sandbox?.proxy_credentials_extra && Array.isArray(sandbox.proxy_credentials_extra)) {
     result.sandbox.proxyCredentials = [
       ...result.sandbox.proxyCredentials,
@@ -301,6 +327,8 @@ function tomlToConfig(toml: Record<string, unknown>): Partial<DeerConfig> {
     result.sandbox = {
       ...(sandbox.runtime !== undefined && { runtime: sandbox.runtime }),
       ...(sandbox.env_passthrough !== undefined && { envPassthrough: sandbox.env_passthrough }),
+      ...(sandbox.write_paths !== undefined && { writePaths: sandbox.write_paths }),
+      ...(sandbox.read_paths !== undefined && { readPaths: sandbox.read_paths }),
       ...(sandbox.proxy_credentials !== undefined && { proxyCredentials: sandbox.proxy_credentials }),
       ...(sandbox.ecosystems_disabled !== undefined && {
         ecosystems: { disabled: sandbox.ecosystems_disabled as string[] },

--- a/packages/deerbox/src/session.ts
+++ b/packages/deerbox/src/session.ts
@@ -373,13 +373,18 @@ export async function prepare(options: PrepareOptions): Promise<PreparedSession>
   // Load the user's env policy to block any vars they've denied
   const envPolicy = loadEnvPolicy();
 
+  // Resolve ~ to HOME in user-configured paths
+  const resolveHome = (p: string) => p.startsWith("~/") ? join(HOME, p.slice(2)) : p;
+  const configWritePaths = config.sandbox.writePaths.map(resolveHome);
+  const configReadPaths = config.sandbox.readPaths.map(resolveHome);
+
   // Build the full sandboxed command via the runtime
   const runtimeOpts = {
     worktreePath,
     repoGitDir: reuseWorktree?.repoGitDir ?? resolve(repoPath, ".git"),
     allowlist: config.network.allowlist,
-    extraReadPaths: ecosystemResult.extraReadPaths,
-    extraWritePaths: ecosystemResult.extraWritePaths,
+    extraReadPaths: [...ecosystemResult.extraReadPaths, ...configReadPaths],
+    extraWritePaths: [...ecosystemResult.extraWritePaths, ...configWritePaths],
     env: { ...ecosystemResult.env, ...sandboxEnvFinal },
     mitmProxy,
     claudeConfigDir,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -190,3 +190,97 @@ env_passthrough = ["ONLY_THIS_VAR"]
     expect(config.sandbox.envPassthrough).toEqual(["ONLY_THIS_VAR"]);
   });
 });
+
+describe("write_paths config", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "deer-config-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("repo-local deer.toml can add extra write paths", async () => {
+    await Bun.write(
+      join(tmpDir, "deer.toml"),
+      `
+[sandbox]
+write_paths_extra = ["~/.my-hook-data", "~/.tmux-tracker"]
+`
+    );
+
+    const config = await loadConfig(tmpDir);
+
+    expect(config.sandbox.writePaths).toContain("~/.my-hook-data");
+    expect(config.sandbox.writePaths).toContain("~/.tmux-tracker");
+  });
+
+  test("global config can override the full write paths list", async () => {
+    const globalDir = join(tmpDir, ".config", "deer");
+    await Bun.write(
+      join(globalDir, "config.toml"),
+      `
+[sandbox]
+write_paths = ["~/.always-writable"]
+`
+    );
+
+    const config = await loadConfig(tmpDir, undefined, join(tmpDir, ".config", "deer", "config.toml"));
+
+    expect(config.sandbox.writePaths).toEqual(["~/.always-writable"]);
+  });
+
+  test("defaults to empty array", () => {
+    expect(DEFAULT_CONFIG.sandbox.writePaths).toBeArray();
+    expect(DEFAULT_CONFIG.sandbox.writePaths).toHaveLength(0);
+  });
+});
+
+describe("read_paths config", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "deer-config-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("repo-local deer.toml can add extra read paths", async () => {
+    await Bun.write(
+      join(tmpDir, "deer.toml"),
+      `
+[sandbox]
+read_paths_extra = ["~/.my-docs", "~/.config/my-tool"]
+`
+    );
+
+    const config = await loadConfig(tmpDir);
+
+    expect(config.sandbox.readPaths).toContain("~/.my-docs");
+    expect(config.sandbox.readPaths).toContain("~/.config/my-tool");
+  });
+
+  test("global config can override the full read paths list", async () => {
+    const globalDir = join(tmpDir, ".config", "deer");
+    await Bun.write(
+      join(globalDir, "config.toml"),
+      `
+[sandbox]
+read_paths = ["~/.shared-docs"]
+`
+    );
+
+    const config = await loadConfig(tmpDir, undefined, join(tmpDir, ".config", "deer", "config.toml"));
+
+    expect(config.sandbox.readPaths).toEqual(["~/.shared-docs"]);
+  });
+
+  test("defaults to empty array", () => {
+    expect(DEFAULT_CONFIG.sandbox.readPaths).toBeArray();
+    expect(DEFAULT_CONFIG.sandbox.readPaths).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #273. Supersedes #290.

Adds `write_paths` and `read_paths` (plus `_extra` variants) to the `[sandbox]` config section, allowing users to grant the sandbox read-write or read-only access to host paths.

## Motivation

Claude Code hooks and tools that read/write outside the worktree (e.g. `~/.tmux-claude-agent-tracker`, `~/.aidb`, local docs) currently break in the SRT sandbox. The `extraReadPaths`/`extraWritePaths` plumbing already exists in `buildSrtSettings` and `SandboxRuntimeOptions`; this PR just exposes them as config.

## Config surface

**Global** (`~/.config/deer/config.toml`):

```toml
[sandbox]
write_paths = ["~/.my-tool"]
read_paths = ["~/.my-docs"]
```

**Repo-local** (`deer.toml`):

```toml
[sandbox]
write_paths_extra = ["~/.my-hook-data"]
read_paths_extra = ["~/.config/my-tool"]
```

- Paths starting with `~/` are resolved to `$HOME` at session start.
- Global sets the base list; repo-local `_extra` appends to it.
- User-configured paths are merged with ecosystem-detected paths (from #292).

## Security

- Config is loaded once at session start before the sandbox launches. A sandboxed agent cannot escalate its own permissions at runtime.
- If an agent writes a malicious `deer.toml` to the worktree, it shows up in the PR diff for human review.
- Whitelisting `/` or other overly-broad paths is user-visible footgun (per maintainer guidance on #273 review: user error, not in scope).

## Changes

- `packages/deerbox/src/config.ts`: new fields + merge logic
- `packages/deerbox/src/session.ts`: `~/` resolution and merging with ecosystem paths
- `deer.toml.example`: commented examples
- `docs/configuration/field-reference.md`: documented in the `[sandbox]` table
- `test/config.test.ts`: 6 new tests covering defaults, global override, repo-local append

## Test plan

- [x] `bun test test/config.test.ts` - all 17 tests pass
- [x] Manual: global `read_paths = ["~/.aidb"]` grants sandboxed Claude read access to `~/.aidb`
- [x] Manual: removing the config restores the deny (verifies the feature is actually doing the work)