### PR TITLE
🦌 Fix --lang=en flag and document language override

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The dashboard UI and generated PR content can be displayed in multiple languages
 
 | Language | `--lang=` value | LLM-translated |
 |----------|----------------|:--------------:|
-| English | *(default)* | |
+| English | `en` *(default)* | |
 | Japanese (日本語) | `ja` | ✓ |
 | Chinese Simplified (简体中文) | `zh` | ✓ |
 | Korean (한국어) | `ko` | ✓ |
@@ -224,9 +224,15 @@ The dashboard UI and generated PR content can be displayed in multiple languages
 deer --lang=zh
 ```
 
+To force English on a machine whose system locale resolves to another language, pass `--lang=en` explicitly:
+
+```sh
+deer --lang=en
+```
+
 Language is detected in this order (first match wins):
 
-1. `--lang=<code>` CLI flag
+1. `--lang=<code>` CLI flag — **overrides all other sources, including system locale**
 2. `CLAUDE_CODE_LOCALE` environment variable (e.g. `CLAUDE_CODE_LOCALE=zh`)
 3. System `LANG` environment variable (e.g. `LANG=zh_CN.UTF-8`)
 4. Default: English

--- a/docs/deerbox/cli-reference.md
+++ b/docs/deerbox/cli-reference.md
@@ -137,5 +137,6 @@ Review and update the environment variable policy. Opens an interactive prompt t
 
 | Flag | Description |
 |------|-------------|
+| `--lang <code>` | UI language: `en`, `ja`, `zh`, `ko`, `ru`. Overrides `CLAUDE_CODE_LOCALE` and system `LANG`. |
 | `-h, --help` | Show help |
 | `-v, --version` | Show version |

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -7,9 +7,9 @@ outline: deep
 
 ## Supported languages
 
-| Language | Code | LLM-translated |
-|----------|------|:--------------:|
-| English | (default) | |
+| Language | `--lang=` value | LLM-translated |
+|----------|----------------|:--------------:|
+| English | `en` *(default)* | |
 | Japanese | `ja` | Yes |
 | Chinese Simplified | `zh` | Yes |
 | Korean | `ko` | Yes |
@@ -17,17 +17,24 @@ outline: deep
 
 ## Setting the language
 
-Pass the `--lang` flag when launching deer:
+Pass the `--lang` flag when launching deer or deerbox:
 
 ```sh
 deer --lang=ja
+deerbox --lang=zh
+```
+
+To force English on a machine whose system locale resolves to another language, pass `--lang=en` explicitly:
+
+```sh
+deer --lang=en
 ```
 
 ## Detection priority
 
 If `--lang` is not specified, deer detects the language automatically. First match wins:
 
-1. `--lang=<code>` CLI flag
+1. `--lang=<code>` CLI flag — **overrides all other sources, including system locale**
 2. `CLAUDE_CODE_LOCALE` environment variable
 3. System `LANG` environment variable (e.g. `LANG=ja_JP.UTF-8`)
 4. Default: English

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -39,6 +39,7 @@ export function detectLang(): Lang {
   const langArg = process.argv.find((a) => a.startsWith("--lang="));
   if (langArg) {
     const val = langArg.split("=")[1]?.toLowerCase();
+    if (val === "en") return "en";
     if (val === "jp" || val === "ja") return "ja";
     if (val === "zh" || val === "zh-cn" || val === "zh_cn") return "zh";
     if (val === "ko") return "ko";

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,0 +1,69 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+
+// detectLang reads process.argv and process.env at call time, so we can
+// manipulate them per-test and restore afterwards.
+
+describe("detectLang", () => {
+  let origArgv: string[];
+  let origLang: string | undefined;
+  let origClaudeLocale: string | undefined;
+
+  beforeEach(() => {
+    origArgv = process.argv.slice();
+    origLang = process.env.LANG;
+    origClaudeLocale = process.env.CLAUDE_CODE_LOCALE;
+    delete process.env.LANG;
+    delete process.env.CLAUDE_CODE_LOCALE;
+  });
+
+  afterEach(() => {
+    process.argv = origArgv;
+    if (origLang === undefined) delete process.env.LANG;
+    else process.env.LANG = origLang;
+    if (origClaudeLocale === undefined) delete process.env.CLAUDE_CODE_LOCALE;
+    else process.env.CLAUDE_CODE_LOCALE = origClaudeLocale;
+  });
+
+  function withArgs(args: string[]) {
+    process.argv = ["bun", "deer", ...args];
+  }
+
+  test("--lang=en overrides LANG=ja_JP.UTF-8", async () => {
+    const { detectLang } = await import("../packages/shared/src/i18n");
+    withArgs(["--lang=en"]);
+    process.env.LANG = "ja_JP.UTF-8";
+    expect(detectLang()).toBe("en");
+  });
+
+  test("--lang=en overrides CLAUDE_CODE_LOCALE=ja", async () => {
+    const { detectLang } = await import("../packages/shared/src/i18n");
+    withArgs(["--lang=en"]);
+    process.env.CLAUDE_CODE_LOCALE = "ja_JP";
+    expect(detectLang()).toBe("en");
+  });
+
+  test("LANG=ja_JP.UTF-8 without --lang flag detects Japanese", async () => {
+    const { detectLang } = await import("../packages/shared/src/i18n");
+    withArgs([]);
+    process.env.LANG = "ja_JP.UTF-8";
+    expect(detectLang()).toBe("ja");
+  });
+
+  test("--lang=ja detects Japanese", async () => {
+    const { detectLang } = await import("../packages/shared/src/i18n");
+    withArgs(["--lang=ja"]);
+    expect(detectLang()).toBe("ja");
+  });
+
+  test("--lang=jp detects Japanese", async () => {
+    const { detectLang } = await import("../packages/shared/src/i18n");
+    withArgs(["--lang=jp"]);
+    expect(detectLang()).toBe("ja");
+  });
+
+  test("defaults to en with no flags or locale env vars", async () => {
+    const { detectLang } = await import("../packages/shared/src/i18n");
+    withArgs([]);
+    expect(detectLang()).toBe("en");
+  });
+});


### PR DESCRIPTION
## Summary

The `--lang=en` CLI flag was silently ignored because `detectLang` had no explicit handler for the `en` code — it fell through to the system locale detection, making it impossible to force English on a machine whose `LANG` is set to another language. This adds the missing `en` case and documents the override behavior.

## Changes

- `packages/shared/src/i18n.ts` — add `if (val === "en") return "en"` branch so `--lang=en` explicitly returns English before any other detection logic runs
- `test/i18n.test.ts` — new test suite covering `--lang=en` override over `LANG` and `CLAUDE_CODE_LOCALE`, fallback locale detection, and the default-to-English path
- `README.md` — document that `--lang=en` can force English, clarify that the `--lang` flag overrides system locale, and show `en` as an explicit value in the language table
- `docs/i18n.md` — same documentation improvements; also notes that `deerbox` accepts `--lang`
- `docs/deerbox/cli-reference.md` — add `--lang <code>` entry to the global flags table

Closes https://github.com/zdavison/deer/issues/299

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.