### PR TITLE
🦌 Skip pruning tasks younger than 8 hours

### DIFF
--- a/packages/deerbox/src/prune.ts
+++ b/packages/deerbox/src/prune.ts
@@ -19,7 +19,22 @@ export interface PruneOptions {
   log?: (msg: string) => void;
 }
 
+const PRUNE_MIN_AGE_MS = 8 * 60 * 60 * 1000; // 8 hours
+
 // ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Extract the creation timestamp from a task ID.
+ * Format: deer_<base36-ms-timestamp><8-char-random-suffix>
+ */
+function taskCreatedAt(taskId: string): Date | null {
+  const withoutPrefix = taskId.slice("deer_".length);
+  if (withoutPrefix.length <= 8) return null;
+  const timestampPart = withoutPrefix.slice(0, -8);
+  const ms = parseInt(timestampPart, 36);
+  if (isNaN(ms) || ms <= 0) return null;
+  return new Date(ms);
+}
 
 function emit(msg: string, opts: PruneOptions): void {
   opts.log?.(msg);
@@ -197,6 +212,9 @@ export async function prune(opts: PruneOptions = {}): Promise<PruneResult> {
       // interactively (no tmux), the proxy PID file is the only signal
       // that the task is still in use.
       if (isProxyAlive(taskDir)) continue;
+
+      const createdAt = taskCreatedAt(taskId);
+      if (createdAt && Date.now() - createdAt.getTime() < PRUNE_MIN_AGE_MS) continue;
 
       emit(`Pruning dangling task: ${taskId}`, opts);
 


### PR DESCRIPTION
## Summary

Adds a minimum age guard to the prune logic so that recently-created tasks are not pruned even if their proxy appears dead. This prevents race conditions where a task is created but its proxy hasn't started yet, causing it to be incorrectly identified as dangling and pruned.

## Changes

- `packages/deerbox/src/prune.ts`: Added `PRUNE_MIN_AGE_MS` constant (8 hours), a `taskCreatedAt()` helper that decodes the creation timestamp from the task ID's base36 prefix, and a guard in the prune loop that skips any task younger than 8 hours

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.