### PR TITLE
🦌 Skip claude config dir setup when resuming existing session

### DIFF
--- a/packages/deerbox/src/session.ts
+++ b/packages/deerbox/src/session.ts
@@ -315,7 +315,12 @@ export async function prepare(options: PrepareOptions): Promise<PreparedSession>
   );
 
   const claudeConfigDir = join(dataDir(), "tasks", repoSlug(repoPath), taskId, "claude-config");
-  await setupClaudeConfigDir(claudeConfigDir, HOME);
+  // On resume, the config dir already exists with read-only git pack files from
+  // the plugin cache. Re-copying would fail with EACCES trying to overwrite them.
+  const claudeConfigExists = await access(claudeConfigDir).then(() => true).catch(() => false);
+  if (!claudeConfigExists) {
+    await setupClaudeConfigDir(claudeConfigDir, HOME);
+  }
 
   onStatus?.("Starting sandbox...");
 


### PR DESCRIPTION
## Summary

When resuming an existing session, the claude config directory already exists and contains read-only git pack files from the plugin cache. Attempting to re-run `setupClaudeConfigDir` would fail with `EACCES` when trying to overwrite those files.

This change guards the setup call so it only runs when the config directory does not already exist.

## Changes

- `packages/deerbox/src/session.ts`: Added existence check before calling `setupClaudeConfigDir` to skip re-initialization on session resume

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.