### PR TITLE
🦌 Fix stdin buffer drain after raw mode exit in VSCode

### DIFF
--- a/packages/shared/src/env-review.ts
+++ b/packages/shared/src/env-review.ts
@@ -107,17 +107,23 @@ export async function runEnvReview(
   return new Promise((resolve) => {
     process.stdin.setRawMode(true);
     process.stdin.resume();
-    process.stdin.setEncoding("utf8");
 
     const cleanup = () => {
       process.stdin.setRawMode(false);
-      process.stdin.pause();
       process.stdin.removeListener("data", onData);
+      // Switch to paused mode so read() drains the internal buffer, then resume
+      // so Ink finds stdin in the expected flowing state. The drain discards any
+      // bytes VSCode's shell integration injects during the raw→cooked transition.
+      process.stdin.pause();
+      let chunk: unknown;
+      while ((chunk = process.stdin.read()) !== null) { /* drain buffered bytes */ }
+      process.stdin.resume();
       out.write(SHOW_CURSOR);
       out.write("\n");
     };
 
-    const onData = (key: string) => {
+    const onData = (data: Buffer | string) => {
+      const key = typeof data === "string" ? data : data.toString();
       if (key === "\r" || key === "\n") {
         // Confirm
         cleanup();

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -158,6 +158,7 @@ async function main() {
   // deerbox (when invoked as a subprocess by deer) skips its own review because it
   // runs non-interactive subcommands (prepare/preflight/etc.) that never show UI.
   await runEnvPreflight();
+  if (process.stdin.isTTY) process.stdin.resume();
 
   // Enter alternate screen buffer
   process.stdout.write("\x1b[?1049h");


### PR DESCRIPTION
## Summary

Fixes a stdin corruption issue caused by VSCode's shell integration injecting bytes during the raw→cooked mode transition when the env review prompt exits. Without draining the buffer, Ink would receive stray bytes and behave unexpectedly.

## Changes

- `packages/shared/src/env-review.ts`: Removed `setEncoding('utf8')` so stdin delivers `Buffer` objects; updated `onData` handler to accept `Buffer | string` and convert explicitly. Reordered cleanup to pause, drain all buffered bytes, then resume stdin so Ink finds it in the expected flowing state.
- `src/cli.tsx`: Added `process.stdin.resume()` guard after `runEnvPreflight()` when stdin is a TTY, ensuring stdin is flowing before Ink takes over.

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.