### PR TITLE
🦌 Add worktree path support to --from flag

### DIFF
--- a/packages/deerbox/src/cli.ts
+++ b/packages/deerbox/src/cli.ts
@@ -387,7 +387,7 @@ Interactive options:
   -c, --continue                Resume the most recent session for this repository
   -m, --model <model>           Claude model (default: ${DEFAULT_MODEL})
   -b, --base-branch <branch>    Branch to base the worktree on
-  -f, --from <source>           Start from a branch, PR (URL/#), GitHub issue URL, or GitHub Actions URL
+  -f, --from <source>           Start from a branch, PR (URL/#), GitHub issue URL, GitHub Actions URL, or worktree path
   -k, --keep                    Keep worktree after Claude exits
 
 Prune options:
@@ -401,6 +401,8 @@ Examples:
   deerbox --from 42 "address review comments"
   deerbox --from https://github.com/org/repo/issues/276 "implement the feature"
   deerbox --from https://github.com/org/repo/actions/runs/123/job/456 "fix the CI failure"
+  deerbox --from ./path/to/worktree "continue work on that branch"
+  deerbox --from /absolute/path/to/worktree "continue work on that branch"
   deerbox prune
   deerbox prune --force`;
 

--- a/packages/deerbox/src/from/index.ts
+++ b/packages/deerbox/src/from/index.ts
@@ -11,15 +11,17 @@ export type { ActionUrlParts, FetchActionLogsResult } from "./action";
 export { prStrategy } from "./pr";
 export { branchStrategy } from "./branch";
 export { issueStrategy } from "./issue";
+export { worktreeStrategy } from "./worktree";
 
 import { actionStrategy } from "./action";
 import { prStrategy } from "./pr";
 import { issueStrategy } from "./issue";
 import { branchStrategy } from "./branch";
+import { worktreeStrategy } from "./worktree";
 import type { FromStrategy, FromResolution } from "./types";
 
 /** Ordered list of strategies. First match wins; branch is the catch-all. */
-const FROM_STRATEGIES: FromStrategy[] = [actionStrategy, prStrategy, issueStrategy, branchStrategy];
+const FROM_STRATEGIES: FromStrategy[] = [actionStrategy, prStrategy, issueStrategy, worktreeStrategy, branchStrategy];
 
 /**
  * Resolve a --from value to a branch, optional PR URL, base branch,
@@ -28,6 +30,7 @@ const FROM_STRATEGIES: FromStrategy[] = [actionStrategy, prStrategy, issueStrate
  * Accepts:
  * - A GitHub Actions URL (run or job)
  * - A GitHub PR URL or PR number
+ * - An absolute or relative path to a git worktree directory (e.g. ./path/to/worktree)
  * - A branch name
  */
 export async function resolveFrom(

--- a/packages/deerbox/src/from/worktree.ts
+++ b/packages/deerbox/src/from/worktree.ts
@@ -1,0 +1,54 @@
+/**
+ * Worktree path strategy — handles absolute or relative paths to git worktree directories.
+ *
+ * Reads the branch name from the worktree's HEAD, then delegates to the
+ * branch strategy to find any associated PR.
+ */
+
+import { isAbsolute, resolve } from "node:path";
+import { stat, readFile } from "node:fs/promises";
+import type { FromStrategy, FromResolution, GhRunner } from "./types";
+import { branchStrategy } from "./branch";
+
+async function readWorktreeBranch(worktreePath: string): Promise<string | null> {
+  try {
+    const headPath = `${worktreePath}/.git`;
+    let gitDir: string;
+
+    // Could be a main worktree (.git is a dir) or a linked worktree (.git is a file)
+    const headStat = await stat(headPath).catch(() => null);
+    if (!headStat) return null;
+
+    if (headStat.isFile()) {
+      // Linked worktree: .git file contains "gitdir: /path/to/.git/worktrees/<name>"
+      const contents = await readFile(headPath, "utf8");
+      const match = contents.match(/^gitdir:\s*(.+)$/m);
+      if (!match) return null;
+      gitDir = match[1].trim();
+    } else {
+      gitDir = headPath;
+    }
+
+    const head = await readFile(`${gitDir}/HEAD`, "utf8");
+    const refMatch = head.match(/^ref:\s*refs\/heads\/(.+)$/m);
+    if (!refMatch) return null;
+    return refMatch[1].trim();
+  } catch {
+    return null;
+  }
+}
+
+export const worktreeStrategy: FromStrategy = {
+  match(from: string): boolean {
+    return isAbsolute(from) || from.startsWith("./") || from.startsWith("../");
+  },
+
+  async resolve(from: string, repoPath: string, defaultBranch: string, runner?: GhRunner): Promise<FromResolution> {
+    const absPath = resolve(from);
+    const branch = await readWorktreeBranch(absPath);
+    if (!branch) {
+      throw new Error(`Could not determine branch from worktree path: ${absPath}`);
+    }
+    return branchStrategy.resolve(branch, repoPath, defaultBranch, runner as GhRunner);
+  },
+};


### PR DESCRIPTION
## Summary

Extends the `--from` flag to accept absolute or relative paths to git worktree directories. Previously, `--from` only supported branch names, PR URLs/numbers, GitHub issue URLs, and GitHub Actions URLs. This change adds a new `worktreeStrategy` that reads the branch name directly from a worktree's `.git` file or directory, then delegates to the existing branch strategy to resolve any associated PR.

## Changes

- `packages/deerbox/src/from/worktree.ts` — new `worktreeStrategy` that matches path-like `--from` values (absolute, `./`, or `../` prefixed), reads the branch from the worktree HEAD, and delegates to `branchStrategy`
- `packages/deerbox/src/from/index.ts` — registers `worktreeStrategy` in the ordered strategy list (before the catch-all `branchStrategy`) and exports it
- `packages/deerbox/src/cli.ts` — updates help text and examples to document the new worktree path option

---

> Created by [deer](https://github.com/zdavison/deer) — review carefully.