### PR TITLE
fix(sandbox): rewrite $HOME/~ prefixes in copied settings.json

### DIFF
--- a/packages/deerbox/src/session.ts
+++ b/packages/deerbox/src/session.ts
@@ -119,21 +119,22 @@ const CLAUDE_DIR_ITEMS: Array<{ name: string; isDir: boolean }> = [
 
 /**
  * Recursively walk a directory and rewrite all `.json` files, replacing
- * occurrences of `oldPrefix` with `newPrefix` in their content.
- * Non-JSON files and files that don't contain the old prefix are skipped.
+ * occurrences of any `oldPrefixes` entry with `newPrefix` in their content.
+ * Non-JSON files and files that don't contain any old prefix are skipped.
  */
-async function rewriteJsonFiles(dir: string, oldPrefix: string, newPrefix: string): Promise<void> {
+async function rewriteJsonFiles(dir: string, oldPrefixes: string[], newPrefix: string): Promise<void> {
   let entries;
   try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
   for (const entry of entries) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      await rewriteJsonFiles(full, oldPrefix, newPrefix);
+      await rewriteJsonFiles(full, oldPrefixes, newPrefix);
     } else if (entry.name.endsWith(".json")) {
       try {
         const raw = await readFile(full, "utf-8");
-        if (!raw.includes(oldPrefix)) continue;
-        await writeFile(full, raw.replaceAll(oldPrefix, newPrefix));
+        let next = raw;
+        for (const p of oldPrefixes) next = next.replaceAll(p, newPrefix);
+        if (next !== raw) await writeFile(full, next);
       } catch { /* unreadable or unwritable — skip */ }
     }
   }
@@ -166,11 +167,17 @@ export async function setupClaudeConfigDir(claudeConfigDir: string, home: string
   }
 
   // Rewrite all references to ~/.claude in copied JSON files so they point
-  // to the per-task config dir. This catches installPath, installLocation,
-  // and any other field that embeds the host config path — a blanket replace
-  // is more resilient than patching individual files.
-  const oldPrefix = join(home, ".claude");
-  await rewriteJsonFiles(claudeConfigDir, oldPrefix, claudeConfigDir);
+  // to the per-task config dir. Covers the literal expanded path plus the
+  // shell-expression forms users commonly write in settings.json (e.g.
+  // hook commands like `$HOME/.claude/hooks/foo.sh`) — at runtime `$HOME`
+  // expands back to the real home, and the sandbox correctly denies that
+  // path. Rewriting the shell forms keeps hooks pointing at the copy in
+  // claudeConfigDir, which the sandbox grants read/exec on.
+  await rewriteJsonFiles(
+    claudeConfigDir,
+    [join(home, ".claude"), "$HOME/.claude", "${HOME}/.claude", "~/.claude"],
+    claudeConfigDir,
+  );
 
   // Copy ~/.claude.json with credentials stripped
   const hostClaudeJson = join(home, ".claude.json");

--- a/test/sandbox/claude-config-dir.test.ts
+++ b/test/sandbox/claude-config-dir.test.ts
@@ -289,6 +289,47 @@ describe("setupClaudeConfigDir", () => {
     expect(entry.installPath).toBe("/opt/plugins/external-plugin/2.0.0");
   });
 
+  test("rewrites $HOME/.claude, ${HOME}/.claude, and ~/.claude shell-expression prefixes in JSON files", async () => {
+    const home = await makeHome();
+    const claudeDir = join(home, ".claude");
+    await mkdir(claudeDir, { recursive: true });
+
+    // settings.json references the hook via $HOME — a shell variable that
+    // expands back to the real home at runtime, bypassing a plain
+    // literal-prefix rewrite and causing the sandbox to deny the path.
+    await writeFile(
+      join(claudeDir, "settings.json"),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                { type: "command", command: "$HOME/.claude/hooks/dollar.sh" },
+                { type: "command", command: "${HOME}/.claude/hooks/braced.sh" },
+                { type: "command", command: "~/.claude/hooks/tilde.sh" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    const taskDir = await makeTaskDir();
+    const claudeConfigDir = join(taskDir, "claude-config");
+    await setupClaudeConfigDir(claudeConfigDir, home);
+
+    const settings = JSON.parse(
+      await readFile(join(claudeConfigDir, "settings.json"), "utf-8"),
+    );
+    const commands = settings.hooks.PreToolUse[0].hooks.map((h: { command: string }) => h.command);
+    expect(commands).toEqual([
+      join(claudeConfigDir, "hooks", "dollar.sh"),
+      join(claudeConfigDir, "hooks", "braced.sh"),
+      join(claudeConfigDir, "hooks", "tilde.sh"),
+    ]);
+  });
+
   test("rewrites ~/.claude paths in nested JSON files", async () => {
     const home = await makeHome();
     const claudeDir = join(home, ".claude");


### PR DESCRIPTION
## Summary
- `rewriteJsonFiles` only replaced the literal expanded-home prefix (e.g. `/Users/z/.claude`). Settings written with `$HOME/.claude/...`, `${HOME}/.claude/...`, or `~/.claude/...` — common for hook `command` strings — survived the copy unchanged.
- At runtime the shell expanded those back to the real home, and the sandbox correctly denied the path → `Operation not permitted` on every Bash tool call that triggers the hook, even though the hook script body had already been copied into `<claudeConfigDir>/hooks/`.
- Fix: extend `rewriteJsonFiles` to accept multiple old prefixes, and pass all three shell-expression forms alongside the literal path.

## Repro (before fix)
With a global `~/.claude/settings.json` like:

```json
{ "hooks": { "PreToolUse": [{ "matcher": "Bash", "hooks": [
  { "type": "command", "command": "$HOME/.claude/hooks/jailed-hook.sh" }
]}] } }
```

Running deer → every Bash tool call emits `PreToolUse:Bash hook error` with `bash: /Users/z/.claude/hooks/jailed-hook.sh: Operation not permitted`.

## Test plan
- [x] Added failing test covering `$HOME/.claude`, `${HOME}/.claude`, and `~/.claude` in `test/sandbox/claude-config-dir.test.ts`
- [x] `bun test test/sandbox/claude-config-dir.test.ts` — 16/16 pass
- [x] Full `bun test` — no new regressions (two preexisting failures on main in `agent.test.ts` and `ecosystems.test.ts` are unrelated and verified pre-existing via stash)

## Notes
Existing prepared worktrees keep their stale settings.json — only newly prepared sessions get the fix. A prune + fresh prepare is the simplest way to clear stragglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)